### PR TITLE
Always use the US locale for number truncation

### DIFF
--- a/ga/src/main/java/nl/tudelft/serg/evosql/fixture/type/DBDouble.java
+++ b/ga/src/main/java/nl/tudelft/serg/evosql/fixture/type/DBDouble.java
@@ -46,7 +46,7 @@ public class DBDouble implements DBType {
 		return truncateDecimals(newValue, decimals);
 	}
 	
-	private String truncateDecimals(double value, int decimals) {
+	static String truncateDecimals(double value, int decimals) {
 		StringBuilder builder = new StringBuilder("0");
 		if (decimals > 0) builder.append('.');
 		for (int i = 0; i < decimals; i++) 

--- a/ga/src/test/java/nl/tudelft/serg/evosql/fixture/type/DBDoubleTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/fixture/type/DBDoubleTest.java
@@ -1,0 +1,43 @@
+package nl.tudelft.serg.evosql.fixture.type;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
+public class DBDoubleTest {
+    @Test
+    public void truncateDecimals() {
+        // Check if integers aren't truncated
+        Assert.assertEquals("3", DBDouble.truncateDecimals(3, 4));
+
+        // Check if decimals are truncated, not rounded
+        Assert.assertEquals("4.5", DBDouble.truncateDecimals(4.52, 1));
+        Assert.assertEquals("4.5", DBDouble.truncateDecimals(4.58, 1));
+
+        // Check if no zeros are added at the end
+        Assert.assertEquals("5.1", DBDouble.truncateDecimals(5.1, 3));
+    }
+
+    @Test
+    public void truncateDecimals_locale() {
+        System.out.printf("The current locale decimal separator is: %s\n", new DecimalFormatSymbols().getDecimalSeparator());
+
+        // Set locale to one where decimal separator is a comma
+        Locale currentLocale = Locale.getDefault();
+        Locale.setDefault(Locale.GERMAN);
+
+        // Check if the current locale uses the comma
+        // If it does *not*, this test is invalid
+        DecimalFormat decimalFormat = new DecimalFormat();
+        Assert.assertEquals("50,4", decimalFormat.format(50.4));
+
+        // Check if truncateDecimals still behaves correctly
+        Assert.assertEquals("50.4", DBDouble.truncateDecimals(50.4, 4));
+
+        // Restore the locale
+        Locale.setDefault(currentLocale);
+    }
+}


### PR DESCRIPTION
Resolves #5

The `DecimalFormat` class uses the system locale by default, resulting in errors when commas are used in strings representing decimal numbers.