### PR TITLE
Improve Gradle tooling

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,21 @@
+version: "{branch} {build}"
+
+build:
+  verbosity: detailed
+
+build_script:
+  - gradlew.bat assemble --info --no-daemon -PbintrayUserName -PbintrayApiKey
+
+test_script:
+  - gradlew.bat :ga:check --info --no-daemon -PbintrayUserName -PbintrayApiKey
+
+cache:
+  - C:\Users\appveyor\.gradle
+
+environment:
+  matrix:
+  - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+
+matrix:
+  fast_finish: true
+

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,6 +17,10 @@ build_script:
 test_script:
   - gradlew.bat :ga:check --no-daemon
 
+branches:
+  only:
+    - master
+
 cache:
   - C:\Users\appveyor\.gradle
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,10 +4,10 @@ build:
   verbosity: detailed
 
 build_script:
-  - gradlew.bat assemble --info --no-daemon -PbintrayUserName -PbintrayApiKey
+  - gradlew.bat assemble --no-daemon
 
 test_script:
-  - gradlew.bat :ga:check --info --no-daemon -PbintrayUserName -PbintrayApiKey
+  - gradlew.bat :ga:check --no-daemon
 
 cache:
   - C:\Users\appveyor\.gradle

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,13 @@
 version: "{branch} {build}"
 
+notifications:
+  - provider: Email
+    to:
+    - '{{commitAuthorEmail}}'
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
 build:
   verbosity: detailed
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,20 @@ language: java
 
 cache:
   directories:
-  - ~/.gradle
+    - ~/.gradle
 
 notifications:
   email: false
 
 script:
-- gradle :ga:check          # runs unit verification tasks
-- gradle jacocoTestReport   # generates Jacoco test report
+  - gradle :ga:check          # runs unit verification tasks
+  - gradle jacocoTestReport   # generates Jacoco test report
 
-# See https://docs.gradle.org/current/userguide/java_plugin.html for
-# more details on the lifecycle events of Java projects in Gradle
+  # See https://docs.gradle.org/current/userguide/java_plugin.html for
+  # more details on the lifecycle events of Java projects in Gradle
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ notifications:
 
 script:
 - gradle assemble     # compile all subprojects
-- gradle :ga:test     # runs unit tests
+- gradle :ga:check    # runs unit verification tasks
 
 # See https://docs.gradle.org/current/userguide/java_plugin.html for
 # more details on the lifecycle events of Java projects in Gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ notifications:
   email: false
 
 script:
-- gradle assemble           # compile all subprojects
 - gradle :ga:check          # runs unit verification tasks
 - gradle jacocoTestReport   # generates Jacoco test report
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ notifications:
   email: false
 
 script:
-- gradle assemble     # compile all subprojects
-- gradle :ga:check    # runs unit verification tasks
+- gradle assemble           # compile all subprojects
+- gradle :ga:check          # runs unit verification tasks
+- gradle jacocoTestReport   # generates Jacoco test report
 
 # See https://docs.gradle.org/current/userguide/java_plugin.html for
 # more details on the lifecycle events of Java projects in Gradle

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # EvoSQL
 
-
 [![Build Status](https://travis-ci.org/SERG-Delft/evosql.svg?branch=master)](https://travis-ci.org/SERG-Delft/evosql)
+[![codecov](https://codecov.io/gh/SERG-Delft/evosql/branch/master/graph/badge.svg)](https://codecov.io/gh/SERG-Delft/evosql)
+
 
 EvoSQL is a tool that automatically generates test data for your SQL queries.
 Behind the scenes, EvoSQL implements a search-based algorithm.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # EvoSQL
 
 [![Build Status](https://travis-ci.org/SERG-Delft/evosql.svg?branch=master)](https://travis-ci.org/SERG-Delft/evosql)
+[![Build status](https://ci.appveyor.com/api/projects/status/api940ix5252bwwg/branch/master?svg=true)](https://ci.appveyor.com/project/pvdstel/evosql/branch/master)
 [![codecov](https://codecov.io/gh/SERG-Delft/evosql/branch/master/graph/badge.svg)](https://codecov.io/gh/SERG-Delft/evosql)
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 allprojects {
     apply plugin: 'maven'
+    apply plugin: 'jacoco'
 
     group = 'nl.tudelft'
     version = '1.0'
@@ -24,5 +25,20 @@ subprojects {
         testCompile group: 'org.mockito', name: 'mockito-all', version: '2.0.2-beta'
     }
 
+    test {
+        jacoco {
+            append = false
+            destinationFile = file("$buildDir/jacoco/jacocoTest.exec")
 
+            finalizedBy jacocoTestReport
+        }
+
+        jacocoTestReport {
+            reports {
+                xml.enabled false
+                csv.enabled false
+                html.destination file("${buildDir}/reports/jacoco")
+            }
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,7 @@ subprojects {
         reports {
             csv.enabled false
             xml.enabled true
-            xml.destination file("${buildDir}/reports/jacoco/report.xml")
-            html.destination file("${buildDir}/reports/jacoco/html")
+            html.enabled true
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 allprojects {
     apply plugin: 'maven'
     apply plugin: 'jacoco'
+    apply plugin: 'findbugs'
 
     group = 'nl.tudelft'
     version = '1.0'
@@ -31,6 +32,7 @@ subprojects {
             destinationFile = file("$buildDir/jacoco/jacocoTest.exec")
 
             finalizedBy jacocoTestReport
+            finalizedBy findbugsMain
         }
 
         jacocoTestReport {
@@ -39,6 +41,18 @@ subprojects {
                 csv.enabled false
                 html.destination file("${buildDir}/reports/jacoco")
             }
+        }
+    }
+
+    findbugs {
+        ignoreFailures = true
+        sourceSets=[sourceSets.main]
+    }
+
+    tasks.withType(FindBugs) {
+        reports {
+            xml.enabled false
+            html.enabled true
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ subprojects {
             reports {
                 xml.enabled false
                 csv.enabled false
-                html.destination file("${buildDir}/reports/jacoco")
+                html.destination file("${buildDir}/reports/jacocoHtml")
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -29,16 +29,15 @@ subprojects {
         jacoco {
             append = false
             destinationFile = file("$buildDir/jacoco/jacocoTest.exec")
-
-            finalizedBy jacocoTestReport
         }
+    }
 
-        jacocoTestReport {
-            reports {
-                xml.enabled false
-                csv.enabled false
-                html.destination file("${buildDir}/reports/jacocoHtml")
-            }
+    jacocoTestReport {
+        reports {
+            csv.enabled false
+            xml.enabled true
+            xml.destination file("${buildDir}/reports/jacoco/report.xml")
+            html.destination file("${buildDir}/reports/jacoco/html")
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 allprojects {
     apply plugin: 'maven'
     apply plugin: 'jacoco'
-    apply plugin: 'findbugs'
 
     group = 'nl.tudelft'
     version = '1.0'
@@ -32,7 +31,6 @@ subprojects {
             destinationFile = file("$buildDir/jacoco/jacocoTest.exec")
 
             finalizedBy jacocoTestReport
-            finalizedBy findbugsMain
         }
 
         jacocoTestReport {
@@ -41,18 +39,6 @@ subprojects {
                 csv.enabled false
                 html.destination file("${buildDir}/reports/jacoco")
             }
-        }
-    }
-
-    findbugs {
-        ignoreFailures = true
-        sourceSets=[sourceSets.main]
-    }
-
-    tasks.withType(FindBugs) {
-        reports {
-            xml.enabled false
-            html.enabled true
         }
     }
 }


### PR DESCRIPTION
Changes Gradle tooling:
- Adds Jacoco test coverage tool
- Attempted to add Findbugs, but didn't work very well on the project currently. Left in as a reverted commit for future reference
- Travis now runs all verification checks, not only unit tests

Run <kbd>gradle jacocoTestReport</kbd> to generate a test report. Currently executed by Travis, so it can be uploaded to Codecov at a later stage.

