### PR TITLE
Remove upper case transformations from GA

### DIFF
--- a/brew/src/test/java/nl/tudelft/serg/evosql/brew/db/EvoSQLRunnerTest.java
+++ b/brew/src/test/java/nl/tudelft/serg/evosql/brew/db/EvoSQLRunnerTest.java
@@ -50,9 +50,9 @@ public class EvoSQLRunnerTest {
         assertThat(brewResult.getPaths().get(1).getFixture().getTables().get(1).getSchema().getName())
                 .isEqualTo("testTable2");
         // GA capitalizes column names
-        assertThat(brewResult.getPaths().get(0).getFixture().getTables().get(0).getRows().get(0).getValues().get("TESTCOLUMN1_1"))
+        assertThat(brewResult.getPaths().get(0).getFixture().getTables().get(0).getRows().get(0).getValues().get("testColumn1_1"))
                 .isEqualTo("'string1'");
-        assertThat(brewResult.getPaths().get(0).getFixture().getTables().get(2).getRows().get(1).getValues().get("TESTCOLUMN3_2"))
+        assertThat(brewResult.getPaths().get(0).getFixture().getTables().get(2).getRows().get(1).getValues().get("testColumn3_2"))
                 .isEqualTo("20");
     }
 

--- a/ga/src/main/java/nl/tudelft/serg/evosql/fixture/FixtureRow.java
+++ b/ga/src/main/java/nl/tudelft/serg/evosql/fixture/FixtureRow.java
@@ -25,7 +25,7 @@ public class FixtureRow implements Cloneable{
 	}
 	
 	public void set(String k, String v) {
-		values.put(k.toUpperCase(), v);
+		values.put(k, v);
 	}
 
 	public String getTable() {
@@ -49,7 +49,7 @@ public class FixtureRow implements Cloneable{
 	}
 
 	public String getValueFor(String column) {
-		return values.get(column.toUpperCase());
+		return values.get(column);
 	}
 
 	@Override

--- a/ga/src/main/java/nl/tudelft/serg/evosql/metaheuristics/GAApproach.java
+++ b/ga/src/main/java/nl/tudelft/serg/evosql/metaheuristics/GAApproach.java
@@ -264,7 +264,7 @@ public class GAApproach extends Approach {
 		
 		for (int i = 0; i < tables.size(); i++) {
 			// Remove table if not in tableSchemas
-			if (!tableSchemas.containsKey(tables.get(i).getName().toUpperCase())) {
+			if (!tableSchemas.containsKey(tables.get(i).getName())) {
 				fixture.removeTable(i);
 				tableCount--;
 			}

--- a/ga/src/main/java/nl/tudelft/serg/evosql/sql/TableSchema.java
+++ b/ga/src/main/java/nl/tudelft/serg/evosql/sql/TableSchema.java
@@ -58,14 +58,14 @@ public class TableSchema implements Serializable {
 	}
 	
 	public String getDropSQL() {
-		return "DROP TABLE \"" + this.name.toUpperCase() + "\" IF EXISTS";
+		return "DROP TABLE \"" + this.name + "\" IF EXISTS";
 	}
 	
 	public String getCreateSQL() {
-		String sql = "CREATE TABLE \"" + this.name.toUpperCase() + "\" ( \n"; 
+		String sql = "CREATE TABLE \"" + this.name + "\" ( \n";
 		
 		for (ColumnSchema cs : columns) {
-			sql += "\t\"" + cs.getName().toUpperCase() + "\" " + cs.getType().getNormalizedTypeString();
+			sql += "\t\"" + cs.getName() + "\" " + cs.getType().getNormalizedTypeString();
 			if (!cs.isNullable())
 				sql += " NOT NULL";
 			sql += ",\n";
@@ -78,11 +78,11 @@ public class TableSchema implements Serializable {
 	}
 	
 	public String getTruncateSQL() {
-		return "TRUNCATE TABLE \"" + this.name.toUpperCase() + "\"";
+		return "TRUNCATE TABLE \"" + this.name + "\"";
 	}
 	
 	public String getInsertSQL() {
-		return "INSERT INTO \"" + this.name.toUpperCase() + "\"";
+		return "INSERT INTO \"" + this.name + "\"";
 	}
 
 	@Override

--- a/ga/src/main/java/nl/tudelft/serg/evosql/sql/parser/SqlSecurerVisitor.java
+++ b/ga/src/main/java/nl/tudelft/serg/evosql/sql/parser/SqlSecurerVisitor.java
@@ -95,7 +95,7 @@ public class SqlSecurerVisitor implements ExpressionVisitor, FromItemVisitor, It
 	private boolean isOuter = true;
 	
 	private String secureName(String name) {
-		name = name.toUpperCase().replaceAll("`", "");
+		name = name.replaceAll("`", "");
 		if (!name.matches("^\".*$")) {
 			name = "\"" + name;
 		}

--- a/ga/src/main/java/nl/tudelft/serg/evosql/sql/parser/TablesNamesFinder.java
+++ b/ga/src/main/java/nl/tudelft/serg/evosql/sql/parser/TablesNamesFinder.java
@@ -138,7 +138,7 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
 
     @Override
     public void visit(Table tableName) {
-        String tableWholeName = tableName.getFullyQualifiedName().toUpperCase();
+        String tableWholeName = tableName.getFullyQualifiedName();
         if (!otherItemNames.contains(tableWholeName.toLowerCase())
                 && !tables.contains(tableWholeName)) {
             tables.add(tableWholeName);

--- a/ga/src/main/java/nl/tudelft/serg/evosql/sql/parser/UsedColumnExtractor.java
+++ b/ga/src/main/java/nl/tudelft/serg/evosql/sql/parser/UsedColumnExtractor.java
@@ -21,7 +21,7 @@ public class UsedColumnExtractor {
 		this.tableSchemas = new HashMap<String, TableSchema>();
 		this.stringEqs = 0;
 		this.dateEqs = 0;
-		tableSchemasInput.forEach((str, ts) -> tableSchemas.put(str.toUpperCase(), ts));
+		tableSchemasInput.forEach((str, ts) -> tableSchemas.put(str, ts));
 	}
 	
 	public Set<ColumnSchema> extract() {

--- a/ga/src/main/java/nl/tudelft/serg/evosql/sql/parser/UsedColumnExtractorVisitor.java
+++ b/ga/src/main/java/nl/tudelft/serg/evosql/sql/parser/UsedColumnExtractorVisitor.java
@@ -149,11 +149,11 @@ public class UsedColumnExtractorVisitor implements ExpressionVisitor, FromItemVi
 
 		TableSource(String tableName, String tableAlias) {
 			if (tableName != null)
-				this.name = tableName.toUpperCase().replaceAll("^\"|\"$", "");
+				this.name = tableName.replaceAll("^\"|\"$", "");
 			if (tableAlias == null)
 				alias = this.name;
 			else
-				alias = tableAlias.toUpperCase().replaceAll("^\"|\"$", "");;
+				alias = tableAlias.replaceAll("^\"|\"$", "");;
 			
 			columnSources = new HashMap<String, ColumnSource>();
 		}
@@ -163,11 +163,11 @@ public class UsedColumnExtractorVisitor implements ExpressionVisitor, FromItemVi
 		}
 		
 		ColumnSource get(String columnName) {
-			return columnSources.get(columnName.toUpperCase());
+			return columnSources.get(columnName);
 		}
 		
 		boolean contains(String columnName) {
-			return columnSources.containsKey(columnName.toUpperCase());
+			return columnSources.containsKey(columnName);
 		}
 	}
 	
@@ -196,8 +196,8 @@ public class UsedColumnExtractorVisitor implements ExpressionVisitor, FromItemVi
 	
 	private void sourceTable(String tableName, String tableAlias) {
 		// Find TableSchema
-		tableName = tableName.toUpperCase().replaceAll("^\"|\"$", "");
-		tableAlias = tableAlias.toUpperCase().replaceAll("^\"|\"$", "");
+		tableName = tableName.replaceAll("^\"|\"$", "");
+		tableAlias = tableAlias.replaceAll("^\"|\"$", "");
 		TableSchema schema = tableSchemas.get(tableName);
 		
 		if (schema == null)
@@ -208,7 +208,7 @@ public class UsedColumnExtractorVisitor implements ExpressionVisitor, FromItemVi
 		
 		// Add all columns
 		for (ColumnSchema cs : schema.getColumns()) {
-			ColumnSource columnSource = new ColumnSource(tableSource, cs.getName().toUpperCase());
+			ColumnSource columnSource = new ColumnSource(tableSource, cs.getName());
 			tableSource.add(columnSource);
 		}
 		
@@ -224,7 +224,7 @@ public class UsedColumnExtractorVisitor implements ExpressionVisitor, FromItemVi
 	 **/
 	private void sourceAllColumns(String tableName) {
 		if (tableName != null)
-			tableName = tableName.toUpperCase().replaceAll("^\"|\"$", "");
+			tableName = tableName.replaceAll("^\"|\"$", "");
 		
 		for (TableSource ts : currentState.stateLevelTableSources.values()) {
 			if (tableName == null || tableName.equals(ts.alias)) {
@@ -238,8 +238,8 @@ public class UsedColumnExtractorVisitor implements ExpressionVisitor, FromItemVi
 
 	private void addUsedColumn(String columnName, String tableName) {
 		if (tableName != null)
-			tableName = tableName.toUpperCase().replaceAll("^\"|\"$", "");
-		columnName = columnName.toUpperCase().replaceAll("^\"|\"$", "");
+			tableName = tableName.replaceAll("^\"|\"$", "");
+		columnName = columnName.replaceAll("^\"|\"$", "");
 		
 		ColumnSource source = getColumnSource(columnName, tableName);
 		
@@ -251,7 +251,7 @@ public class UsedColumnExtractorVisitor implements ExpressionVisitor, FromItemVi
 	 */
 	private void useAllColumns(String tableName) {
 		if (tableName != null)
-			tableName = tableName.toUpperCase().replaceAll("^\"|\"$", "");
+			tableName = tableName.replaceAll("^\"|\"$", "");
 		
 		for (TableSource ts : currentState.stateLevelTableSources.values()) {
 			if (tableName == null || tableName.equals(ts.alias)) {
@@ -264,12 +264,12 @@ public class UsedColumnExtractorVisitor implements ExpressionVisitor, FromItemVi
 	
 	private void linkColumns(String column1Name, String table1Name, String column2Name, String table2Name) {
 		if (table1Name != null)
-			table1Name = table1Name.toUpperCase().replaceAll("^\"|\"$", "");
-		column1Name = column1Name.toUpperCase().replaceAll("^\"|\"$", "");
+			table1Name = table1Name.replaceAll("^\"|\"$", "");
+		column1Name = column1Name.replaceAll("^\"|\"$", "");
 
 		if (table2Name != null)
-			table2Name = table2Name.toUpperCase().replaceAll("^\"|\"$", "");
-		column2Name = column2Name.toUpperCase().replaceAll("^\"|\"$", "");
+			table2Name = table2Name.replaceAll("^\"|\"$", "");
+		column2Name = column2Name.replaceAll("^\"|\"$", "");
 		
 		// Get sources
 		ColumnSource source1 = getColumnSource(column1Name, table1Name);
@@ -311,8 +311,8 @@ public class UsedColumnExtractorVisitor implements ExpressionVisitor, FromItemVi
 	
 	private ColumnSource getColumnSource(String columnName, String tableName) {
 		if (tableName != null)
-			tableName = tableName.toUpperCase().replaceAll("^\"|\"$", "");
-		columnName = columnName.toUpperCase().replaceAll("^\"|\"$", "");
+			tableName = tableName.replaceAll("^\"|\"$", "");
+		columnName = columnName.replaceAll("^\"|\"$", "");
 		
 		TableSource tableSource;
 		if (tableName != null) {
@@ -951,7 +951,7 @@ public class UsedColumnExtractorVisitor implements ExpressionVisitor, FromItemVi
 			}
 			// Strip quotes
 			if (columnName != null)
-				columnName = columnName.toUpperCase().replaceAll("^\"|\"$", "");
+				columnName = columnName.replaceAll("^\"|\"$", "");
 			currentState.columnSource = new ColumnSource(currentState.stateSource, columnName);
 		}
 		

--- a/ga/src/test/java/nl/tudelft/serg/evosql/fixture/FixtureTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/fixture/FixtureTest.java
@@ -43,11 +43,11 @@ public class FixtureTest {
 
         Assert.assertEquals(
                 "-- Table: t1\n" +
-                " Row #1: C1='1',C2='Mauricio',\n" +
-                " Row #2: C1='2',C2='Jeroen',\n" +
+                " Row #1: c1='1',c2='Mauricio',\n" +
+                " Row #2: c1='2',c2='Jeroen',\n" +
                 "\n" +
                 "-- Table: t2\n" +
-                " Row #1: C3='10.0',C4='Mozhan',\n" +
-                " Row #2: C3='25.5',C4='Annibale',", fixture.prettyPrint());
+                " Row #1: c3='10.0',c4='Mozhan',\n" +
+                " Row #2: c3='25.5',c4='Annibale',", fixture.prettyPrint());
     }
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/mock/TableSchemaMocks.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/mock/TableSchemaMocks.java
@@ -10,23 +10,23 @@ import nl.tudelft.serg.evosql.sql.TableSchema;
 public class TableSchemaMocks {
 	public static TableSchema T1() {
 		List<ColumnSchema> csList = new ArrayList<ColumnSchema>();
-		TableSchema ts = new TableSchema("T1", csList);
+		TableSchema ts = new TableSchema("t1", csList);
 		
-		csList.add(new ColumnSchema(ts, "A", new DBInteger(), false, false));
-		csList.add(new ColumnSchema(ts, "B", new DBInteger(), false, false));
-		csList.add(new ColumnSchema(ts, "C", new DBInteger(), false, false));
-		csList.add(new ColumnSchema(ts, "D", new DBInteger(), false, false));
+		csList.add(new ColumnSchema(ts, "a", new DBInteger(), false, false));
+		csList.add(new ColumnSchema(ts, "b", new DBInteger(), false, false));
+		csList.add(new ColumnSchema(ts, "c", new DBInteger(), false, false));
+		csList.add(new ColumnSchema(ts, "d", new DBInteger(), false, false));
 		
 		return ts;
 	}
 	
 	public static TableSchema T2() {
 		List<ColumnSchema> csList = new ArrayList<ColumnSchema>();
-		TableSchema ts = new TableSchema("T2", csList);
+		TableSchema ts = new TableSchema("t2", csList);
 		
-		csList.add(new ColumnSchema(ts, "A", new DBInteger(), false, false));
-		csList.add(new ColumnSchema(ts, "B", new DBInteger(), false, false));
-		csList.add(new ColumnSchema(ts, "C", new DBInteger(), false, false));
+		csList.add(new ColumnSchema(ts, "a", new DBInteger(), false, false));
+		csList.add(new ColumnSchema(ts, "b", new DBInteger(), false, false));
+		csList.add(new ColumnSchema(ts, "c", new DBInteger(), false, false));
 		
 		return ts;
 	}

--- a/ga/src/test/java/nl/tudelft/serg/evosql/sql/parser/SqlSecurerTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/sql/parser/SqlSecurerTest.java
@@ -11,186 +11,186 @@ public class SqlSecurerTest {
 	@Test
 	public void secureSelectAllQuery() {
 		String sql = new SqlSecurer("SELECT * FROM Table").getSecureSql();
-		Assert.assertEquals(sql, "SELECT * FROM \"TABLE\"");
+		Assert.assertEquals(sql, "SELECT * FROM \"Table\"");
 	}
 
 	@Test
 	public void secureSelectColumnsQuery() {
 		String sql = new SqlSecurer("SELECT Column1, Column2, Column3 FROM Table").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\", \"COLUMN2\", \"COLUMN3\" FROM \"TABLE\"");
+		Assert.assertEquals(sql, "SELECT \"Column1\", \"Column2\", \"Column3\" FROM \"Table\"");
 	}
 
 	@Test
 	public void secureColumnAliasQuery() {
 		String sql = new SqlSecurer("SELECT Column1 AS col1, Column2 AS col2, Column3 FROM Table").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\" AS \"COL1\", \"COLUMN2\" AS \"COL2\", \"COLUMN3\" FROM \"TABLE\"");
+		Assert.assertEquals(sql, "SELECT \"Column1\" AS \"col1\", \"Column2\" AS \"col2\", \"Column3\" FROM \"Table\"");
 	}
 
 	@Test
 	public void secureSelectTableColumnsQuery() {
 		String sql = new SqlSecurer("SELECT Table.Column1, Table.Column2, Table.Column3 FROM Table").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"TABLE\".\"COLUMN1\", \"TABLE\".\"COLUMN2\", \"TABLE\".\"COLUMN3\" FROM \"TABLE\"");
+		Assert.assertEquals(sql, "SELECT \"Table\".\"Column1\", \"Table\".\"Column2\", \"Table\".\"Column3\" FROM \"Table\"");
 	}
 
 	@Test
 	public void secureSelectTableAllColumnsQuery() {
 		String sql = new SqlSecurer("SELECT Table.* FROM Table").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"TABLE\".* FROM \"TABLE\"");
+		Assert.assertEquals(sql, "SELECT \"Table\".* FROM \"Table\"");
 	}
 
 	@Test
 	public void secureSelectTableAliasColumnsQuery() {
 		String sql = new SqlSecurer("SELECT t1.Column1, t1.Column2, t1.Column3 FROM Table AS t1").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"T1\".\"COLUMN1\", \"T1\".\"COLUMN2\", \"T1\".\"COLUMN3\" FROM \"TABLE\" AS \"T1\"");
+		Assert.assertEquals(sql, "SELECT \"t1\".\"Column1\", \"t1\".\"Column2\", \"t1\".\"Column3\" FROM \"Table\" AS \"t1\"");
 	}
 
 	@Test
 	public void secureSecureQuery() {
-		String sql = new SqlSecurer("SELECT \"COLUMN1\", \"COLUMN2\", \"COLUMN3\" FROM \"TABLE\"").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\", \"COLUMN2\", \"COLUMN3\" FROM \"TABLE\"");
+		String sql = new SqlSecurer("SELECT \"COLUMN1\", \"COLUMN2\", \"COLUMN3\" FROM \"Table\"").getSecureSql();
+		Assert.assertEquals(sql, "SELECT \"COLUMN1\", \"COLUMN2\", \"COLUMN3\" FROM \"Table\"");
 	}
 
 	@Test
 	public void secureWhereColumnsQuery() {
 		String sql = new SqlSecurer("SELECT Column1 FROM Table WHERE Column2 = 10 AND 'Column3' = column3").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\" FROM \"TABLE\" WHERE \"COLUMN2\" = 10 AND 'Column3' = \"COLUMN3\"");
+		Assert.assertEquals(sql, "SELECT \"Column1\" FROM \"Table\" WHERE \"Column2\" = 10 AND 'Column3' = \"column3\"");
 	}
 
 	@Test
 	public void secureAggregateColumnsQuery() {
 		String sql = new SqlSecurer("SELECT SUM(column1) FROM Table").getSecureSql();
-		Assert.assertEquals(sql, "SELECT SUM(\"COLUMN1\") FROM \"TABLE\"");
+		Assert.assertEquals(sql, "SELECT SUM(\"column1\") FROM \"Table\"");
 	}
 
 	@Test
 	public void secureAggregateHavingColumnsQuery() {
 		String sql = new SqlSecurer("SELECT SUM(column1) FROM Table HAVING AVG(column2) > 50").getSecureSql();
-		Assert.assertEquals(sql, "SELECT SUM(\"COLUMN1\") FROM \"TABLE\" HAVING AVG(\"COLUMN2\") > 50");
+		Assert.assertEquals(sql, "SELECT SUM(\"column1\") FROM \"Table\" HAVING AVG(\"column2\") > 50");
 	}
 
 	@Test
 	public void secureSubqueryColumnsQuery() {
 		String sql = new SqlSecurer("SELECT * FROM (SELECT column1, Column2 FROM Table) t1").getSecureSql();
-		Assert.assertEquals(sql, "SELECT * FROM (SELECT \"COLUMN1\", \"COLUMN2\" FROM \"TABLE\") \"T1\"");
+		Assert.assertEquals(sql, "SELECT * FROM (SELECT \"column1\", \"Column2\" FROM \"Table\") \"t1\"");
 	}
 	
 	@Test
 	public void secureBackticksKeywordQuery() {
 		String sql = new SqlSecurer("SELECT `Column1`, `primary` FROM Table").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\", \"PRIMARY\" FROM \"TABLE\"");
+		Assert.assertEquals(sql, "SELECT \"Column1\", \"primary\" FROM \"Table\"");
 	}
 	
 	@Test
 	public void securePrimaryNoBackticksQuery() {
 		String sql = new SqlSecurer("SELECT table.primary FROM table").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"TABLE\".\"PRIMARY\" FROM \"TABLE\"");
+		Assert.assertEquals(sql, "SELECT \"table\".\"primary\" FROM \"table\"");
 	}
 	
 	@Test
 	public void securePrimaryPartOfWordQuery() {
 		String sql = new SqlSecurer("SELECT primary_word FROM table").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"PRIMARY_WORD\" FROM \"TABLE\"");
+		Assert.assertEquals(sql, "SELECT \"primary_word\" FROM \"table\"");
 	}
 	
 	@Test
 	public void securePrimaryPartOfWord2Query() {
 		String sql = new SqlSecurer("SELECT the_primary_word FROM table").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"THE_PRIMARY_WORD\" FROM \"TABLE\"");
+		Assert.assertEquals(sql, "SELECT \"the_primary_word\" FROM \"table\"");
 	}
 	
 	@Test
 	public void secureRemoveOrderBy() {
 		String sql = new SqlSecurer("SELECT Column1 FROM Table ORDER BY column1").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\" FROM \"TABLE\"");
+		Assert.assertEquals(sql, "SELECT \"Column1\" FROM \"Table\"");
 	}
 	
 	@Test
 	public void leaveInnerOrderBy() {
 		String sql = new SqlSecurer("SELECT Column1 FROM Table WHERE column2 = (SELECT c FROM t ORDER BY c) ORDER BY Column1").getSecureSql();
-		Assert.assertEquals("SELECT \"COLUMN1\" FROM \"TABLE\" WHERE \"COLUMN2\" = (SELECT \"C\" FROM \"T\" ORDER BY \"C\")", sql);
+		Assert.assertEquals("SELECT \"Column1\" FROM \"Table\" WHERE \"column2\" = (SELECT \"c\" FROM \"t\" ORDER BY \"c\")", sql);
 	}
 	
 	@Test
 	public void secureAliasSingleQuotes() {
 		String sql = new SqlSecurer("SELECT Column1 AS 'Column' FROM Table").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\" AS \"COLUMN\" FROM \"TABLE\"");
+		Assert.assertEquals(sql, "SELECT \"Column1\" AS \"Column\" FROM \"Table\"");
 	}
 	
 	@Test
 	public void secureAliasSingleQuotesTwice() {
 		String sql = new SqlSecurer("SELECT Column1 AS 'Column', Column2 AS 'ColumnTwo' FROM Table").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\" AS \"COLUMN\", \"COLUMN2\" AS \"COLUMNTWO\" FROM \"TABLE\"");
+		Assert.assertEquals(sql, "SELECT \"Column1\" AS \"Column\", \"Column2\" AS \"ColumnTwo\" FROM \"Table\"");
 	}
 	
 	@Test
 	public void secureExists() {
 		String sql = new SqlSecurer("SELECT Column1 AS 'Column', Column2 AS 'ColumnTwo' FROM Table WHERE EXISTS (SELECT col FROM tab)").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\" AS \"COLUMN\", \"COLUMN2\" AS \"COLUMNTWO\" FROM \"TABLE\" WHERE EXISTS (SELECT \"COL\" FROM \"TAB\")");
+		Assert.assertEquals(sql, "SELECT \"Column1\" AS \"Column\", \"Column2\" AS \"ColumnTwo\" FROM \"Table\" WHERE EXISTS (SELECT \"col\" FROM \"tab\")");
 	}
 	
 	@Test
 	public void secureColumnCondition() {
 		String sql = new SqlSecurer("SELECT Column1 AS 'Column', Column2 AS 'ColumnTwo' FROM Table WHERE Column1").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\" AS \"COLUMN\", \"COLUMN2\" AS \"COLUMNTWO\" FROM \"TABLE\" WHERE \"COLUMN1\" = 1");
+		Assert.assertEquals(sql, "SELECT \"Column1\" AS \"Column\", \"Column2\" AS \"ColumnTwo\" FROM \"Table\" WHERE \"Column1\" = 1");
 	}
 	
 	@Test
 	public void secureColumnCondition2() {
 		String sql = new SqlSecurer("SELECT Column1 AS 'Column', Column2 AS 'ColumnTwo' FROM Table WHERE Column1 = 2 AND Column1 OR Column3").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\" AS \"COLUMN\", \"COLUMN2\" AS \"COLUMNTWO\" FROM \"TABLE\" WHERE \"COLUMN1\" = 2 AND \"COLUMN1\" = 1 OR \"COLUMN3\" = 1");
+		Assert.assertEquals(sql, "SELECT \"Column1\" AS \"Column\", \"Column2\" AS \"ColumnTwo\" FROM \"Table\" WHERE \"Column1\" = 2 AND \"Column1\" = 1 OR \"Column3\" = 1");
 	}
 	
 	@Test
 	public void secureGroupBy() {
 		String sql = new SqlSecurer("SELECT Column1 AS 'Column', Column2 AS 'ColumnTwo' FROM Table GROUP BY Column1, Column2").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\" AS \"COLUMN\", \"COLUMN2\" AS \"COLUMNTWO\" FROM \"TABLE\" GROUP BY \"COLUMN1\", \"COLUMN2\"");
+		Assert.assertEquals(sql, "SELECT \"Column1\" AS \"Column\", \"Column2\" AS \"ColumnTwo\" FROM \"Table\" GROUP BY \"Column1\", \"Column2\"");
 	}
 	
 	@Test
 	public void secureDatefunction() {
 		String sql = new SqlSecurer("SELECT Column1 AS 'Column', Column2 AS 'ColumnTwo' FROM Table WHERE date(column1) <= date('2015-02-01')").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\" AS \"COLUMN\", \"COLUMN2\" AS \"COLUMNTWO\" FROM \"TABLE\" WHERE TIMESTAMP(\"COLUMN1\") <= TIMESTAMP('2015-02-01')");
+		Assert.assertEquals(sql, "SELECT \"Column1\" AS \"Column\", \"Column2\" AS \"ColumnTwo\" FROM \"Table\" WHERE TIMESTAMP(\"column1\") <= TIMESTAMP('2015-02-01')");
 	}
 	
 	@Test
 	public void secureDatefunction2() {
 		String sql = new SqlSecurer("SELECT Column1 AS 'Column', Column2 AS 'ColumnTwo' FROM Table WHERE (date(column1) <= date('2015-02-01'))").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\" AS \"COLUMN\", \"COLUMN2\" AS \"COLUMNTWO\" FROM \"TABLE\" WHERE (TIMESTAMP(\"COLUMN1\") <= TIMESTAMP('2015-02-01'))");
+		Assert.assertEquals(sql, "SELECT \"Column1\" AS \"Column\", \"Column2\" AS \"ColumnTwo\" FROM \"Table\" WHERE (TIMESTAMP(\"column1\") <= TIMESTAMP('2015-02-01'))");
 	}
 	
 	@Test
 	public void secureCurdatefunction() {
 		String sql = new SqlSecurer("SELECT Column1 AS 'Column', Column2 AS 'ColumnTwo' FROM Table WHERE date(column1) <= CURDATE()").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\" AS \"COLUMN\", \"COLUMN2\" AS \"COLUMNTWO\" FROM \"TABLE\" WHERE TIMESTAMP(\"COLUMN1\") <= CURDATE()");
+		Assert.assertEquals(sql, "SELECT \"Column1\" AS \"Column\", \"Column2\" AS \"ColumnTwo\" FROM \"Table\" WHERE TIMESTAMP(\"column1\") <= CURDATE()");
 	}
 	
 	@Test
 	public void secureForUpdate() {
 		String sql = new SqlSecurer("SELECT column1 FROM table FOR UPDATE").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\" FROM \"TABLE\"");
+		Assert.assertEquals(sql, "SELECT \"column1\" FROM \"table\"");
 	}
 
 	@Test
 	public void secureEqualsNull() {
 		String sql = new SqlSecurer("SELECT column1 FROM table WHERE column2 = NULL").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\" FROM \"TABLE\" WHERE \"COLUMN2\" IS NULL");
+		Assert.assertEquals(sql, "SELECT \"column1\" FROM \"table\" WHERE \"column2\" IS NULL");
 	}
 	
 	@Test
 	public void secureNotEqualsNull() {
 		String sql = new SqlSecurer("SELECT column1 FROM table WHERE column2 != NULL").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\" FROM \"TABLE\" WHERE \"COLUMN2\" IS NOT NULL");
+		Assert.assertEquals(sql, "SELECT \"column1\" FROM \"table\" WHERE \"column2\" IS NOT NULL");
 	}
 	
 	@Test
 	public void secureNotEqualsNull2() {
 		String sql = new SqlSecurer("SELECT column1 FROM table WHERE column2 <> NULL").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\" FROM \"TABLE\" WHERE \"COLUMN2\" IS NOT NULL");
+		Assert.assertEquals(sql, "SELECT \"column1\" FROM \"table\" WHERE \"column2\" IS NOT NULL");
 	}
 	
 	@Test
 	public void leaveBinaryOpNull() {
 		String sql = new SqlSecurer("SELECT column1 FROM table WHERE column2 >= NULL").getSecureSql();
-		Assert.assertEquals(sql, "SELECT \"COLUMN1\" FROM \"TABLE\" WHERE \"COLUMN2\" >= NULL");
+		Assert.assertEquals(sql, "SELECT \"column1\" FROM \"table\" WHERE \"column2\" >= NULL");
 	}
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/sql/parser/UsedColumnExtractorTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/sql/parser/UsedColumnExtractorTest.java
@@ -24,8 +24,8 @@ public class UsedColumnExtractorTest {
 	public void setUp() {
 		this.extractor = Mockito.mock(SchemaExtractor.class);
 		
-		Mockito.when(extractor.extract("T1")).thenReturn(TableSchemaMocks.T1());
-		Mockito.when(extractor.extract("T2")).thenReturn(TableSchemaMocks.T2());
+		Mockito.when(extractor.extract("t1")).thenReturn(TableSchemaMocks.T1());
+		Mockito.when(extractor.extract("t2")).thenReturn(TableSchemaMocks.T2());
 		Mockito.when(extractor.getTablesFromQuery(Mockito.anyString())).thenCallRealMethod();
 	}
 	
@@ -37,27 +37,20 @@ public class UsedColumnExtractorTest {
 	}
 	
 	private boolean contains(Set<ColumnSchema> columns, String tableName, String columnName) {
-		String uTableName = tableName.toUpperCase();
-		String uColumnName = columnName.toUpperCase();
 		return columns.stream()
-				.filter(cs -> cs.getName().equals(uColumnName) && cs.getTable().getName().equals(uTableName))
+				.filter(cs -> cs.getName().equals(columnName) && cs.getTable().getName().equals(tableName))
 				.findAny()
 				.isPresent();
 	}
 	
 	// Assumes both column schemas are present
 	private boolean areLinked(Set<ColumnSchema> columns, String table1Name, String column1Name, String table2Name, String column2Name) {
-		String uTable1Name = table1Name.toUpperCase();
-		String uColumn1Name = column1Name.toUpperCase();
-		String uTable2Name = table2Name.toUpperCase();
-		String uColumn2Name = column2Name.toUpperCase();
-		
 		ColumnSchema cs1 = columns.stream()
-				.filter(cs -> cs.getName().equals(uColumn1Name) && cs.getTable().getName().equals(uTable1Name))
+				.filter(cs -> cs.getName().equals(column1Name) && cs.getTable().getName().equals(table1Name))
 				.findFirst().get();
 		
 		ColumnSchema cs2 = columns.stream()
-				.filter(cs -> cs.getName().equals(uColumn2Name) && cs.getTable().getName().equals(uTable2Name))
+				.filter(cs -> cs.getName().equals(column2Name) && cs.getTable().getName().equals(table2Name))
 				.findFirst().get();
 		
 		Set<ColumnSchema> colSet = cs1.getSeedSourceColumns();

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/AggregatesTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/AggregatesTest.java
@@ -11,27 +11,27 @@ import org.junit.Test;
 public class AggregatesTest extends TestBase {
 	@Test
 	public void test1() {
-		assertTrue(testExecutePath("SELECT Product, AVG(Price) FROM products GROUP BY Product HAVING AVG(Price) = 15"));
+		assertTrue(testExecutePath("SELECT PRODUCT, AVG(PRICE) FROM PRODUCTS GROUP BY PRODUCT HAVING AVG(PRICE) = 15"));
 	}
 	
 	@Test
 	public void test2() {
-		assertTrue(testExecutePath("SELECT Product, AVG(Price) FROM products GROUP BY Product HAVING MIN(Price) < 10 AND MAX(Price) BETWEEN 20 AND 30"));
+		assertTrue(testExecutePath("SELECT PRODUCT, AVG(PRICE) FROM PRODUCTS GROUP BY PRODUCT HAVING MIN(PRICE) < 10 AND MAX(PRICE) BETWEEN 20 AND 30"));
 	}
 	
 	@Test
 	public void test3() {
-		assertTrue(testExecutePath("SELECT Product, AVG(Price) FROM products GROUP BY Product HAVING SUM(Price) BETWEEN 2 and 3"));
+		assertTrue(testExecutePath("SELECT PRODUCT, AVG(PRICE) FROM PRODUCTS GROUP BY PRODUCT HAVING SUM(PRICE) BETWEEN 2 AND 3"));
 	}
 	
 	/** Special case where Product has to be null **/
 	@Test
 	public void test4() {
-		assertTrue(testExecutePath("SELECT Product, AVG(Price) FROM products GROUP BY Product HAVING COUNT(Product) = 0"));
+		assertTrue(testExecutePath("SELECT PRODUCT, AVG(PRICE) FROM PRODUCTS GROUP BY PRODUCT HAVING COUNT(PRODUCT) = 0"));
 	}
 	
 	@Test
 	public void test5() {
-		assertTrue(testExecutePath("SELECT Product, AVG(Price) FROM products GROUP BY Product HAVING COUNT(Product) = 3"));
+		assertTrue(testExecutePath("SELECT PRODUCT, AVG(PRICE) FROM PRODUCTS GROUP BY PRODUCT HAVING COUNT(PRODUCT) = 3"));
 	}
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/BetweenTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/BetweenTest.java
@@ -8,6 +8,6 @@ public class BetweenTest extends TestBase {
 
 	@Test
 	public void test1() {
-		assertTrue(testExecutePath("SELECT * FROM Products WHERE Price BETWEEN 0 AND 100"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS WHERE PRICE BETWEEN 0 AND 100"));
 	}
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/CountTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/CountTest.java
@@ -8,12 +8,12 @@ public class CountTest extends TestBase {
 	
 	@Test
 	public void test1() {
-		assertTrue(testExecutePath("SELECT COUNT(*) FROM Products"));
+		assertTrue(testExecutePath("SELECT COUNT(*) FROM PRODUCTS"));
 	}
 	
 	@Test
 	public void test2() {
-		assertTrue(testExecutePath("SELECT COUNT(*) FROM Products WHERE Price > 50"));
+		assertTrue(testExecutePath("SELECT COUNT(*) FROM PRODUCTS WHERE PRICE > 50"));
 	}
 	
 	/**
@@ -26,12 +26,12 @@ public class CountTest extends TestBase {
 	
 	@Test
 	public void test4() {
-		assertTrue(testExecutePath("SELECT COUNT(*) FROM Products HAVING COUNT(*) > 0"));
+		assertTrue(testExecutePath("SELECT COUNT(*) FROM PRODUCTS HAVING COUNT(*) > 0"));
 	}
 	
 	@Test
 	public void test5() {
-		assertTrue(testExecutePath("SELECT COUNT(*) FROM Products WHERE Price > 50 AND Price < 60 HAVING COUNT(*) > 0"));
+		assertTrue(testExecutePath("SELECT COUNT(*) FROM PRODUCTS WHERE PRICE > 50 AND PRICE < 60 HAVING COUNT(*) > 0"));
 	}
 
 	/**
@@ -39,7 +39,7 @@ public class CountTest extends TestBase {
 	 */
 	@Test
 	public void test6() {
-		assertTrue(testExecutePath("SELECT Product, COUNT(*) FROM Products GROUP BY Product HAVING COUNT(*) > 1"));
+		assertTrue(testExecutePath("SELECT PRODUCT, COUNT(*) FROM PRODUCTS GROUP BY PRODUCT HAVING COUNT(*) > 1"));
 	}
 
 	/**
@@ -47,7 +47,7 @@ public class CountTest extends TestBase {
 	 */
 	@Test
 	public void test7() {
-		assertTrue(testExecutePath("SELECT Product, COUNT(*) FROM Products GROUP BY Product HAVING COUNT(*) > 3"));
+		assertTrue(testExecutePath("SELECT PRODUCT, COUNT(*) FROM PRODUCTS GROUP BY PRODUCT HAVING COUNT(*) > 3"));
 	}
 
 	/**
@@ -55,7 +55,7 @@ public class CountTest extends TestBase {
 	 */
 	@Test
 	public void test8() {
-		assertTrue(testExecutePath("SELECT COUNT(Product) FROM Products HAVING COUNT(Product) > COUNT(DISTINCT Product) AND COUNT(DISTINCT Product) > 1"));
+		assertTrue(testExecutePath("SELECT COUNT(PRODUCT) FROM PRODUCTS HAVING COUNT(PRODUCT) > COUNT(DISTINCT PRODUCT) AND COUNT(DISTINCT PRODUCT) > 1"));
 	}
 
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/DistinctTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/DistinctTest.java
@@ -8,17 +8,17 @@ public class DistinctTest extends TestBase {
 	
 	@Test
 	public void test1() {
-		assertTrue(testExecutePath("SELECT DISTINCT Product FROM Products"));
+		assertTrue(testExecutePath("SELECT DISTINCT PRODUCT FROM PRODUCTS"));
 	}
 	
 	@Test
 	public void test2() {
-		assertTrue(testExecutePath("SELECT DISTINCT Product FROM Products WHERE Price > 50 AND Price < 75"));
+		assertTrue(testExecutePath("SELECT DISTINCT PRODUCT FROM PRODUCTS WHERE PRICE > 50 AND PRICE < 75"));
 	}
 
 	@Test
 	public void test3() {
-		assertTrue(testExecutePath("SELECT DISTINCT Product FROM Products GROUP BY Product HAVING SUM(Price) > 50 AND SUM(Price) < 75"));
+		assertTrue(testExecutePath("SELECT DISTINCT PRODUCT FROM PRODUCTS GROUP BY PRODUCT HAVING SUM(PRICE) > 50 AND SUM(PRICE) < 75"));
 	}
 
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/ExistsTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/ExistsTest.java
@@ -7,11 +7,11 @@ import org.junit.Test;
 public class ExistsTest extends TestBase {
 	@Test
 	public void test1() {
-		assertTrue(testExecutePath("SELECT Product, Price FROM Products WHERE EXISTS (SELECT ID FROM Product_detail WHERE Type = 10)"));
+		assertTrue(testExecutePath("SELECT PRODUCT, PRICE FROM PRODUCTS WHERE EXISTS (SELECT ID FROM PRODUCT_DETAIL WHERE TYPE = 10)"));
 	}
 
 	@Test
 	public void test2() {
-		assertTrue(testExecutePath("SELECT Product, Price FROM Products pr WHERE EXISTS (SELECT ID FROM Product_detail WHERE Type = pr.ID)"));
+		assertTrue(testExecutePath("SELECT PRODUCT, PRICE FROM PRODUCTS PR WHERE EXISTS (SELECT ID FROM PRODUCT_DETAIL WHERE TYPE = PR.ID)"));
 	}
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/GroupByTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/GroupByTest.java
@@ -11,7 +11,7 @@ public class GroupByTest extends TestBase {
 	 */
 	@Test
 	public void test1() {
-		assertTrue(testExecutePath("SELECT Product, AVG(Price) FROM products GROUP BY Product"));
+		assertTrue(testExecutePath("SELECT PRODUCT, AVG(PRICE) FROM PRODUCTS GROUP BY PRODUCT"));
 	}
 	
 	/**
@@ -19,7 +19,7 @@ public class GroupByTest extends TestBase {
 	 */
 	@Test
 	public void test2() {
-		assertTrue(testExecutePath("SELECT Product, AVG(Price) FROM products WHERE Price > 4 GROUP BY Product"));
+		assertTrue(testExecutePath("SELECT PRODUCT, AVG(PRICE) FROM PRODUCTS WHERE PRICE > 4 GROUP BY PRODUCT"));
 	}
 
 	/**
@@ -27,6 +27,6 @@ public class GroupByTest extends TestBase {
 	 */
 	@Test
 	public void test3() {
-		assertTrue(testExecutePath("SELECT Product, AVG(Price) FROM products WHERE (Price > 4 AND Product = 'BINGO') OR (Product = 'TEST') GROUP BY Product"));
+		assertTrue(testExecutePath("SELECT PRODUCT, AVG(PRICE) FROM PRODUCTS WHERE (PRICE > 4 AND PRODUCT = 'BINGO') OR (PRODUCT = 'TEST') GROUP BY PRODUCT"));
 	}
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/HavingTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/HavingTest.java
@@ -10,7 +10,7 @@ public class HavingTest extends TestBase {
 	 */
 	@Test
 	public void test1() {
-		assertTrue(testExecutePath("SELECT Product, AVG(Price) FROM products GROUP BY Product HAVING AVG(Price) > 5 AND AVG(Price) < 10"));
+		assertTrue(testExecutePath("SELECT PRODUCT, AVG(PRICE) FROM PRODUCTS GROUP BY PRODUCT HAVING AVG(PRICE) > 5 AND AVG(PRICE) < 10"));
 	}
 	
 	/**
@@ -18,7 +18,7 @@ public class HavingTest extends TestBase {
 	 */
 	@Test
 	public void test2() {
-		assertTrue(testExecutePath("SELECT Product, AVG(Price) FROM products WHERE LENGTH(Product) = 5 GROUP BY Product HAVING AVG(Price) > 0 AND AVG(Price) < 10"));
+		assertTrue(testExecutePath("SELECT PRODUCT, AVG(PRICE) FROM PRODUCTS WHERE LENGTH(PRODUCT) = 5 GROUP BY PRODUCT HAVING AVG(PRICE) > 0 AND AVG(PRICE) < 10"));
 	}
 	
 	/**
@@ -26,7 +26,7 @@ public class HavingTest extends TestBase {
 	 */
 	@Test
 	public void testHavingExists() {
-		assertTrue(testExecutePath("SELECT Product FROM products t GROUP BY Product HAVING EXISTS (SELECT * FROM Product_Detail t2 WHERE t.Product = t2.Name)"));
+		assertTrue(testExecutePath("SELECT PRODUCT FROM PRODUCTS T GROUP BY PRODUCT HAVING EXISTS (SELECT * FROM PRODUCT_DETAIL T2 WHERE T.PRODUCT = T2.NAME)"));
 	}
 	
 	/**
@@ -34,6 +34,6 @@ public class HavingTest extends TestBase {
 	 */
 	@Test
 	public void testHavingExistsAndSome() {
-		assertTrue(testExecutePath("SELECT Product FROM products t GROUP BY Product HAVING EXISTS (SELECT * FROM Product_Detail t2 WHERE t.Product = t2.Name) AND SUM(t.Price) > 50"));
+		assertTrue(testExecutePath("SELECT PRODUCT FROM PRODUCTS T GROUP BY PRODUCT HAVING EXISTS (SELECT * FROM PRODUCT_DETAIL T2 WHERE T.PRODUCT = T2.NAME) AND SUM(T.PRICE) > 50"));
 	}
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/InTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/InTest.java
@@ -11,7 +11,7 @@ public class InTest extends TestBase {
 	 */
 	@Test
 	public void test1() {
-		assertTrue(testExecutePath("SELECT Product, Price FROM Products WHERE Product IN ('HI', 'BYE')"));
+		assertTrue(testExecutePath("SELECT PRODUCT, PRICE FROM PRODUCTS WHERE PRODUCT IN ('HI', 'BYE')"));
 	}
 	
 	/**
@@ -19,7 +19,7 @@ public class InTest extends TestBase {
 	 */
 	@Test
 	public void test2() {
-		assertTrue(testExecutePath("SELECT Product, Price FROM Products WHERE Product IN (SELECT Name FROM Product_Detail)"));
+		assertTrue(testExecutePath("SELECT PRODUCT, PRICE FROM PRODUCTS WHERE PRODUCT IN (SELECT NAME FROM PRODUCT_DETAIL)"));
 	}
 	
 	/**
@@ -27,7 +27,7 @@ public class InTest extends TestBase {
 	 */
 	@Test
 	public void test3() {
-		assertTrue(testExecutePath("SELECT Product, Price FROM Products WHERE Product IN (SELECT Name FROM Product_Detail WHERE LENGTH(Name) > 1)"));
+		assertTrue(testExecutePath("SELECT PRODUCT, PRICE FROM PRODUCTS WHERE PRODUCT IN (SELECT NAME FROM PRODUCT_DETAIL WHERE LENGTH(NAME) > 1)"));
 	}
 	
 	/**
@@ -35,6 +35,6 @@ public class InTest extends TestBase {
 	 */
 	@Test
 	public void test4() {
-		assertTrue(testExecutePath("SELECT Product, Price FROM Products WHERE Product IN (SELECT Name FROM Product_Detail WHERE Type = 10)"));
+		assertTrue(testExecutePath("SELECT PRODUCT, PRICE FROM PRODUCTS WHERE PRODUCT IN (SELECT NAME FROM PRODUCT_DETAIL WHERE TYPE = 10)"));
 	}
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/InnerJoinTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/InnerJoinTest.java
@@ -10,7 +10,7 @@ public class InnerJoinTest extends TestBase {
 	 */
 	@Test
 	public void test1() {
-		assertTrue(testExecutePath("SELECT * FROM Products t1 INNER JOIN PRODUCT_DETAIL t2 ON t1.ID = t2.ID"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS T1 INNER JOIN PRODUCT_DETAIL T2 ON T1.ID = T2.ID"));
 	}
 	
 	/**
@@ -18,7 +18,7 @@ public class InnerJoinTest extends TestBase {
 	 */
 	@Test
 	public void testJoinString() {
-		assertTrue(testExecutePath("SELECT * FROM Products t1 INNER JOIN PRODUCT_DETAIL t2 ON t1.PRoduct = t2.Name"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS T1 INNER JOIN PRODUCT_DETAIL T2 ON T1.PRODUCT = T2.NAME"));
 	}
 
 	/**
@@ -26,7 +26,7 @@ public class InnerJoinTest extends TestBase {
 	 */
 	@Test
 	public void test2() {
-		assertTrue(testExecutePath("SELECT * FROM Products t1 INNER JOIN PRODUCT_DETAIL t2 ON t1.ID = t2.ID WHERE t2.TYPE = 10"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS T1 INNER JOIN PRODUCT_DETAIL T2 ON T1.ID = T2.ID WHERE T2.TYPE = 10"));
 	}
 
 	/**
@@ -34,7 +34,7 @@ public class InnerJoinTest extends TestBase {
 	 */
 	@Test
 	public void test3() {
-		assertTrue(testExecutePath("SELECT Product FROM Products t1 INNER JOIN PRODUCT_DETAIL t2 ON t1.ID = t2.ID WHERE t2.TYPE = 10 GROUP BY Product HAVING AVG(Price) > 5 AND AVG(Price) < 10"));
+		assertTrue(testExecutePath("SELECT PRODUCT FROM PRODUCTS T1 INNER JOIN PRODUCT_DETAIL T2 ON T1.ID = T2.ID WHERE T2.TYPE = 10 GROUP BY PRODUCT HAVING AVG(PRICE) > 5 AND AVG(PRICE) < 10"));
 	}
 	
 	/**
@@ -42,7 +42,7 @@ public class InnerJoinTest extends TestBase {
 	 */
 	@Test
 	public void test4() {
-		assertTrue(testExecutePath("SELECT Product FROM Products t1 INNER JOIN PRODUCT_DETAIL t2 ON t1.ID = t2.ID WHERE t1.Price > 10"));
+		assertTrue(testExecutePath("SELECT PRODUCT FROM PRODUCTS T1 INNER JOIN PRODUCT_DETAIL T2 ON T1.ID = T2.ID WHERE T1.PRICE > 10"));
 	}
 	
 	/**
@@ -50,7 +50,7 @@ public class InnerJoinTest extends TestBase {
 	 */
 	@Test
 	public void test5() {
-		assertTrue(testExecutePath("SELECT Product FROM Products t1 INNER JOIN PRODUCT_DETAIL t2 ON t1.ID = t2.ID WHERE t1.Price > 10 AND t2.TYPE = 10"));
+		assertTrue(testExecutePath("SELECT PRODUCT FROM PRODUCTS T1 INNER JOIN PRODUCT_DETAIL T2 ON T1.ID = T2.ID WHERE T1.PRICE > 10 AND T2.TYPE = 10"));
 	}
 	
 	/**
@@ -58,7 +58,7 @@ public class InnerJoinTest extends TestBase {
 	 */
 	@Test
 	public void test6() {
-		assertTrue(testExecutePath("SELECT Product FROM Products t1 INNER JOIN PRODUCT_DETAIL t2 ON t1.ID = t2.ID WHERE t1.Price > t2.TYPE - 10 AND t1.Price < t2.TYPE + 10"));
+		assertTrue(testExecutePath("SELECT PRODUCT FROM PRODUCTS T1 INNER JOIN PRODUCT_DETAIL T2 ON T1.ID = T2.ID WHERE T1.PRICE > T2.TYPE - 10 AND T1.PRICE < T2.TYPE + 10"));
 	}
 	
 	/**
@@ -66,6 +66,6 @@ public class InnerJoinTest extends TestBase {
 	 */
 	@Test
 	public void test7() {
-		assertTrue(testExecutePath("SELECT Product FROM Products t1 INNER JOIN PRODUCT_DETAIL t2 ON t1.ID = t2.ID INNER JOIN PRODUCT_DETAIL t3 ON t1.ID = t3.ID - 10"));
+		assertTrue(testExecutePath("SELECT PRODUCT FROM PRODUCTS T1 INNER JOIN PRODUCT_DETAIL T2 ON T1.ID = T2.ID INNER JOIN PRODUCT_DETAIL T3 ON T1.ID = T3.ID - 10"));
 	}
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/LeftJoinTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/LeftJoinTest.java
@@ -19,7 +19,7 @@ public class LeftJoinTest extends TestBase {
 	 */
 	@Test
 	public void test2() {
-		assertTrue(testExecutePath("SELECT * FROM Products t1 LEFT JOIN PRODUCT_DETAIL t2 ON t1.ID = t2.ID WHERE t2.TYPE IS NULL"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS T1 LEFT JOIN PRODUCT_DETAIL T2 ON T1.ID = T2.ID WHERE T2.TYPE IS NULL"));
 	}
 	
 	/**
@@ -27,7 +27,7 @@ public class LeftJoinTest extends TestBase {
 	 */
 	@Test
 	public void test3() {
-		assertTrue(testExecutePath("SELECT * FROM Products t1 LEFT JOIN PRODUCT_DETAIL t2 ON t1.ID = t2.ID WHERE t1.Price > 10 AND t1.Price < 20"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS T1 LEFT JOIN PRODUCT_DETAIL T2 ON T1.ID = T2.ID WHERE T1.PRICE > 10 AND T1.PRICE < 20"));
 	} 
 	
 	/**
@@ -35,6 +35,6 @@ public class LeftJoinTest extends TestBase {
 	 */
 	@Test
 	public void test4() {
-		assertTrue(testExecutePath("SELECT * FROM Products t1 LEFT JOIN PRODUCT_DETAIL t2 ON t1.ID = t2.ID WHERE ((t1.ID IS NULL) AND (t2.ID IS NULL)) AND (t1.Price > 10 AND t1.Price < 20)"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS T1 LEFT JOIN PRODUCT_DETAIL T2 ON T1.ID = T2.ID WHERE ((T1.ID IS NULL) AND (T2.ID IS NULL)) AND (T1.PRICE > 10 AND T1.PRICE < 20)"));
 	} 
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/LikeTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/LikeTest.java
@@ -9,37 +9,37 @@ public class LikeTest extends TestBase {
 	/** Converts to an EQUAL operation **/
 	@Test
 	public void test1() {
-		assertTrue(testExecutePath("SELECT * FROM Products WHERE Product LIKE 'A'"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS WHERE PRODUCT LIKE 'A'"));
 	}
 	
 	@Test
 	public void test2() {
-		assertTrue(testExecutePath("SELECT * FROM Products WHERE Product LIKE 'A_'"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS WHERE PRODUCT LIKE 'A_'"));
 	}
 	
 	@Test
 	public void test3() {
-		assertTrue(testExecutePath("SELECT * FROM Products WHERE Product LIKE '%_A'"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS WHERE PRODUCT LIKE '%_A'"));
 	}
 	
 	@Test
 	public void test4() {
-		assertTrue(testExecutePath("SELECT * FROM Products WHERE Product LIKE '%A'"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS WHERE PRODUCT LIKE '%A'"));
 	}
 	
 	@Test
 	public void test5() {
-		assertTrue(testExecutePath("SELECT * FROM Products WHERE Product LIKE '%A%'"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS WHERE PRODUCT LIKE '%A%'"));
 	}
 	
 	@Test
 	public void test6() {
-		assertTrue(testExecutePath("SELECT * FROM Products WHERE Product LIKE 'A%'"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS WHERE PRODUCT LIKE 'A%'"));
 	}
 	
 	@Test
 	public void test7() {
-		assertTrue(testExecutePath("SELECT * FROM Products WHERE Product LIKE 'WEST%'"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS WHERE PRODUCT LIKE 'WEST%'"));
 	}
 
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/LimitTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/LimitTest.java
@@ -15,7 +15,7 @@ public class LimitTest extends TestBase {
 
 	@Test
 	public void test2() {
-		assertTrue(testExecutePath("SELECT Product, Price FROM Products WHERE Price > 100 AND Price < 150 LIMIT 2"));
+		assertTrue(testExecutePath("SELECT PRODUCT, PRICE FROM PRODUCTS WHERE PRICE > 100 AND PRICE < 150 LIMIT 2"));
 	}
 	
 	/**
@@ -24,7 +24,7 @@ public class LimitTest extends TestBase {
 	 */
 	@Test @Ignore
 	public void test3() {
-		assertTrue(testExecutePath("SELECT Product, Price FROM Products LIMIT 2 OFFSET 20"));
+		assertTrue(testExecutePath("SELECT PRODUCT, PRICE FROM PRODUCTS LIMIT 2 OFFSET 20"));
 	}
 
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/NullTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/NullTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 public class NullTest extends TestBase {
 	@Test
 	public void test1() {
-		assertTrue(testExecutePath("SELECT * FROM Products WHERE Product IS NULL"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS WHERE PRODUCT IS NULL"));
 	}
 
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/RightJoinTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/RightJoinTest.java
@@ -22,7 +22,7 @@ public class RightJoinTest extends TestBase {
 	 */
 	@Test
 	public void test2() {
-		assertTrue(testExecutePath("SELECT * FROM Products t1 RIGHT JOIN PRODUCT_DETAIL t2 ON t1.ID = t2.ID WHERE t1.Price IS NULL"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS T1 RIGHT JOIN PRODUCT_DETAIL T2 ON T1.ID = T2.ID WHERE T1.PRICE IS NULL"));
 	}
 	
 	/**
@@ -30,7 +30,7 @@ public class RightJoinTest extends TestBase {
 	 */
 	@Test
 	public void test3() {
-		assertTrue(testExecutePath("SELECT * FROM Products t1 RIGHT JOIN PRODUCT_DETAIL t2 ON t1.ID = t2.ID WHERE t2.Type = 10"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS T1 RIGHT JOIN PRODUCT_DETAIL T2 ON T1.ID = T2.ID WHERE T2.TYPE = 10"));
 	}
 	
 	/**
@@ -38,7 +38,7 @@ public class RightJoinTest extends TestBase {
 	 */
 	@Test
 	public void test4() {
-		assertTrue(testExecutePath("SELECT * FROM Products t1 RIGHT JOIN PRODUCT_DETAIL t3 ON t1.ID = t3.ID - 1 RIGHT JOIN PRODUCT_DETAIL t2 ON t1.ID = t2.ID WHERE t2.Type = 10"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS T1 RIGHT JOIN PRODUCT_DETAIL T3 ON T1.ID = T3.ID - 1 RIGHT JOIN PRODUCT_DETAIL T2 ON T1.ID = T2.ID WHERE T2.TYPE = 10"));
 	}
 	
 	/**
@@ -46,7 +46,7 @@ public class RightJoinTest extends TestBase {
 	 */
 	@Test
 	public void test5() {
-		assertTrue(testExecutePath("SELECT * FROM Products t1 LEFT JOIN PRODUCT_DETAIL t3 ON t1.ID = t3.ID RIGHT JOIN PRODUCT_DETAIL t2 ON t1.ID = t2.ID WHERE t2.Type = 10"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS T1 LEFT JOIN PRODUCT_DETAIL T3 ON T1.ID = T3.ID RIGHT JOIN PRODUCT_DETAIL T2 ON T1.ID = T2.ID WHERE T2.TYPE = 10"));
 	}
 	
 	/**
@@ -54,12 +54,12 @@ public class RightJoinTest extends TestBase {
 	 */
 	@Test
 	public void test6() {
-		assertTrue(testExecutePath("SELECT * FROM Products t1 RIGHT JOIN PRODUCT_DETAIL t2 ON t1.ID = t2.ID INNER JOIN extra_product t3 ON t2.Type = t3.ID WHERE t1.ID IS NULL AND t2.ID IS NULL"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS T1 RIGHT JOIN PRODUCT_DETAIL T2 ON T1.ID = T2.ID INNER JOIN EXTRA_PRODUCT T3 ON T2.TYPE = T3.ID WHERE T1.ID IS NULL AND T2.ID IS NULL"));
 	}
 	
 	@Test
 	public void testRightJoinWithNullsBasedOnEspocrmQ10P6() {
-		String sql = "SELECT * FROM STRINGS RIGHT JOIN STRINGS2 ON STRINGS.C1 = STRINGS2.C1 AND STRINGS2.C2 = 'testPortalId' AND STRINGS2.C3 = '1' WHERE ( STRINGS.C1 IS NULL ) AND ( STRINGS2.C1 IS NULL ) AND ( STRINGS2.C2 IS NULL ) AND ( STRINGS2.C3 IS NULL ) ";
+		String sql = "SELECT * FROM STRINGS RIGHT JOIN STRINGS2 ON STRINGS.C1 = STRINGS2.C1 AND STRINGS2.C2 = 'TESTPORTALID' AND STRINGS2.C3 = '1' WHERE ( STRINGS.C1 IS NULL ) AND ( STRINGS2.C1 IS NULL ) AND ( STRINGS2.C2 IS NULL ) AND ( STRINGS2.C3 IS NULL ) ";
 		
 		assertTrue(testExecutePath(sql));
 	}
@@ -68,67 +68,67 @@ public class RightJoinTest extends TestBase {
 	public void testRightJoinWithNulls2BasedOnEspocrmQ21P15() {
 		
 		createTable("PORTAL", "CREATE TABLE PORTAL ("+
-		        "  id varchar(24),"+
-		        "  name varchar(100) ,"+
-		        "  deleted int,"+
-		        "  custom_id varchar(36) ,"+
-		        "  is_active int,"+
-		        "  tab_list varchar(255),"+
-		        "  quick_create_list varchar(255),"+
-		        "  theme varchar(255) ,"+
-		        "  language varchar(255) ,"+
-		        "  time_zone varchar(255) ,"+
-		        "  date_format varchar(255) ,"+
-		        "  time_format varchar(255) ,"+
-		        "  week_start int,"+
-		        "  default_currency varchar(255) ,"+
-		        "  dashboard_layout varchar(255),"+
-		        "  dashlets_options varchar(255),"+
-		        "  custom_url varchar(255),"+
-		        "  modified_at datetime ,"+
-		        "  created_at datetime ,"+
-		        "  modified_by_id varchar(24) ,"+
-		        "  created_by_id varchar(24) ,"+
-		        "  logo_id varchar(24) ,"+
-		        "  company_logo_id varchar(24) "+
+		        "  ID VARCHAR(24),"+
+		        "  NAME VARCHAR(100) ,"+
+		        "  DELETED INT,"+
+		        "  CUSTOM_ID VARCHAR(36) ,"+
+		        "  IS_ACTIVE INT,"+
+		        "  TAB_LIST VARCHAR(255),"+
+		        "  QUICK_CREATE_LIST VARCHAR(255),"+
+		        "  THEME VARCHAR(255) ,"+
+		        "  LANGUAGE VARCHAR(255) ,"+
+		        "  TIME_ZONE VARCHAR(255) ,"+
+		        "  DATE_FORMAT VARCHAR(255) ,"+
+		        "  TIME_FORMAT VARCHAR(255) ,"+
+		        "  WEEK_START INT,"+
+		        "  DEFAULT_CURRENCY VARCHAR(255) ,"+
+		        "  DASHBOARD_LAYOUT VARCHAR(255),"+
+		        "  DASHLETS_OPTIONS VARCHAR(255),"+
+		        "  CUSTOM_URL VARCHAR(255),"+
+		        "  MODIFIED_AT DATETIME ,"+
+		        "  CREATED_AT DATETIME ,"+
+		        "  MODIFIED_BY_ID VARCHAR(24) ,"+
+		        "  CREATED_BY_ID VARCHAR(24) ,"+
+		        "  LOGO_ID VARCHAR(24) ,"+
+		        "  COMPANY_LOGO_ID VARCHAR(24) "+
 		        ")");
 		
 		createTable("USER", "CREATE TABLE USER ("+
-				"  id varchar(24) ,"+
-				"  deleted int ,"+
-				"  is_admin int  ,"+
-				"  user_name varchar(50) ,"+
-				"  password varchar(150) ,"+
-				"  salutation_name varchar(255) ,"+
-				"  first_name varchar(100) DEFAULT '',"+
-				"  last_name varchar(100) DEFAULT '',"+
-				"  is_active int  ,"+
-				"  is_portal_user int  ,"+
-				"  is_super_admin int  ,"+
-				"  title varchar(100) ,"+
-				"  gender varchar(255) DEFAULT '',"+
-				"  created_at datetime ,"+
-				"  default_team_id varchar(24) ,"+
-				"  contact_id varchar(24) ,"+
-				"  avatar_id varchar(24) ,"+
+				"  ID VARCHAR(24) ,"+
+				"  DELETED INT ,"+
+				"  IS_ADMIN INT  ,"+
+				"  USER_NAME VARCHAR(50) ,"+
+				"  PASSWORD VARCHAR(150) ,"+
+				"  SALUTATION_NAME VARCHAR(255) ,"+
+				"  FIRST_NAME VARCHAR(100) DEFAULT '',"+
+				"  LAST_NAME VARCHAR(100) DEFAULT '',"+
+				"  IS_ACTIVE INT  ,"+
+				"  IS_PORTAL_USER INT  ,"+
+				"  IS_SUPER_ADMIN INT  ,"+
+				"  TITLE VARCHAR(100) ,"+
+				"  GENDER VARCHAR(255) DEFAULT '',"+
+				"  CREATED_AT DATETIME ,"+
+				"  DEFAULT_TEAM_ID VARCHAR(24) ,"+
+				"  CONTACT_ID VARCHAR(24) ,"+
+				"  AVATAR_ID VARCHAR(24) ,"+
 				")");
 		
 		createTable("ATTACHMENT", "CREATE TABLE ATTACHMENT ("+
-				"  id varchar(24) ,"+
-				"  name varchar(255) ,"+
-				"  deleted int ,"+
-				"  type varchar(100) ,"+
-				"  size int ,"+
-				"  source_id varchar(36) ,"+
-				"  created_at datetime ,"+
-				"  role varchar(36) ,"+
-				"  storage varchar(24) ,"+
-				"  global int  ,"+
-				"  parent_id varchar(24) ,"+
-				"  parent_type varchar(100) ,"+
-				"  related_id varchar(24) ,"+
-				"  related_type varchar(100) ,"+
-				"  created_by_id varchar(24) ,"+
+				"  ID VARCHAR(24) ,"+
+				"  NAME VARCHAR(255) ,"+
+				"  DELETED INT ,"+
+				"  TYPE VARCHAR(100) ,"+
+				"  SIZE INT ,"+
+				"  SOURCE_ID VARCHAR(36) ,"+
+				"  CREATED_AT DATETIME ,"+
+				"  ROLE VARCHAR(36) ,"+
+				"  STORAGE VARCHAR(24) ,"+
+				"  GLOBAL INT  ,"+
+				"  PARENT_ID VARCHAR(24) ,"+
+				"  PARENT_TYPE VARCHAR(100) ,"+
+				"  RELATED_ID VARCHAR(24) ,"+
+				"  RELATED_TYPE VARCHAR(100) ,"+
+				"  CREATED_BY_ID VARCHAR(24) ,"+
 				")");
 		
 		String sql = "SELECT PORTAL.ID AS ID, PORTAL.NAME AS NAME, PORTAL.DELETED AS DELETED, PORTAL.CUSTOM_ID AS CUSTOMID, PORTAL.IS_ACTIVE AS ISACTIVE, PORTAL.TAB_LIST AS TABLIST, PORTAL.QUICK_CREATE_LIST AS QUICKCREATELIST, PORTAL.THEME AS THEME, PORTAL.LANGUAGE AS LANGUAGE, PORTAL.TIME_ZONE AS TIMEZONE, PORTAL.DATE_FORMAT AS DATEFORMAT, PORTAL.TIME_FORMAT AS TIMEFORMAT, PORTAL.WEEK_START AS WEEKSTART, PORTAL.DEFAULT_CURRENCY AS DEFAULTCURRENCY, PORTAL.DASHBOARD_LAYOUT AS DASHBOARDLAYOUT, PORTAL.DASHLETS_OPTIONS AS DASHLETSOPTIONS, PORTAL.CUSTOM_URL AS CUSTOMURL, PORTAL.MODIFIED_AT AS MODIFIEDAT, PORTAL.CREATED_AT AS CREATEDAT, PORTAL.MODIFIED_BY_ID AS MODIFIEDBYID, TRIM(CONCAT(MODIFIEDBY.FIRST_NAME, ' ', MODIFIEDBY.LAST_NAME)) AS MODIFIEDBYNAME, PORTAL.CREATED_BY_ID AS CREATEDBYID, TRIM(CONCAT(CREATEDBY.FIRST_NAME, ' ', CREATEDBY.LAST_NAME)) AS CREATEDBYNAME, LOGO.NAME AS LOGONAME, PORTAL.LOGO_ID AS LOGOID, COMPANYLOGO.NAME AS COMPANYLOGONAME, PORTAL.COMPANY_LOGO_ID AS COMPANYLOGOID "

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/SelectTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/SelectTest.java
@@ -8,6 +8,6 @@ public class SelectTest extends TestBase {
 	
 	@Test
 	public void test1() {
-		assertTrue(testExecutePath("SELECT Product, Price FROM Products"));
+		assertTrue(testExecutePath("SELECT PRODUCT, PRICE FROM PRODUCTS"));
 	}
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/StringsTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/StringsTest.java
@@ -68,7 +68,7 @@ public class StringsTest extends TestBase {
 	@Test
 	public void testStringFunctionsReverse() {
 		String sql = "SELECT * FROM STRINGS WHERE " +
-				"reverse(C1) = 'Mauricio' and C2 = 'Annibale' and C3 = 'Mozhan'";
+				"REVERSE(C1) = 'Mauricio' and C2 = 'Annibale' and C3 = 'Mozhan'";
 		
 		assertTrue(testExecutePath(sql));
 	}
@@ -76,7 +76,7 @@ public class StringsTest extends TestBase {
 	@Test
 	public void refrigeratorReverse() {
 		String sql = "SELECT * FROM STRINGS WHERE " +
-				"reverse(C1) = 'refrigerator'";
+				"REVERSE(C1) = 'refrigerator'";
 		
 		assertTrue(testExecutePath(sql));
 	}

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/StringsTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/StringsTest.java
@@ -9,7 +9,7 @@ public class StringsTest extends TestBase {
 	
 	@Test
 	public void testManyStringEqualities() {
-		String sql = "SELECT * FROM Strings WHERE " +
+		String sql = "SELECT * FROM STRINGS WHERE " +
 				"C1 = 'Mauricio' and C2 = 'Annibale' and C3 = 'Mozhan' and C4 = 'Jeroen@jeroen.com' and C5 = 'Arie' " +
 				"and C6 = '1_2' and C7 = '_Stroopwafel'";
 		
@@ -18,7 +18,7 @@ public class StringsTest extends TestBase {
 	
 	@Test
 	public void testStringGreater() {
-		String sql = "SELECT * FROM Strings WHERE " +
+		String sql = "SELECT * FROM STRINGS WHERE " +
 				"( C1 > 'Mauricio' ) ";
 		
 		assertTrue(testExecutePath(sql));
@@ -26,7 +26,7 @@ public class StringsTest extends TestBase {
 	
 	@Test
 	public void testStringGreaterEqual() {
-		String sql = "SELECT * FROM Strings WHERE " +
+		String sql = "SELECT * FROM STRINGS WHERE " +
 				"( C1 >= 'Mozhan' ) ";
 		
 		assertTrue(testExecutePath(sql));
@@ -34,7 +34,7 @@ public class StringsTest extends TestBase {
 	
 	@Test
 	public void testStringSmaller() {
-		String sql = "SELECT * FROM Strings WHERE " +
+		String sql = "SELECT * FROM STRINGS WHERE " +
 				"( C1 < 'Arie' ) ";
 		
 		assertTrue(testExecutePath(sql));
@@ -42,7 +42,7 @@ public class StringsTest extends TestBase {
 	
 	@Test
 	public void testStringSmallerEqual() {
-		String sql = "SELECT * FROM Strings WHERE " +
+		String sql = "SELECT * FROM STRINGS WHERE " +
 				"( C1 <= 'Annibale' ) ";
 		
 		assertTrue(testExecutePath(sql));
@@ -50,7 +50,7 @@ public class StringsTest extends TestBase {
 
 	@Test
 	public void testEqualitiesAndLike() {
-		String sql = "SELECT * FROM Strings WHERE " +
+		String sql = "SELECT * FROM STRINGS WHERE " +
 				"C1 = 'Mauricio' and C2 = 'Annibale' and C3 = 'Mozhan' and C4 = 'Jeroen' and C5 = 'Arie' " +
 				"and C6 = '1_2' and C7 = 'Stroopwafel' and C8 like '%John%Doe%'";
 		
@@ -59,15 +59,15 @@ public class StringsTest extends TestBase {
 	
 	@Test
 	public void testStringFunctions() {
-		String sql = "SELECT * FROM Strings WHERE " +
-				"C1 = 'Mauricio' and C2 = 'Annibale' and C3 = 'Mozhan' and C4 = 'Jeroen' and C5 = 'Arie' and length(c6) = 7";
+		String sql = "SELECT * FROM STRINGS WHERE " +
+				"C1 = 'Mauricio' and C2 = 'Annibale' and C3 = 'Mozhan' and C4 = 'Jeroen' and C5 = 'Arie' and LENGTH(C6) = 7";
 		
 		assertTrue(testExecutePath(sql));
 	}
 
 	@Test
 	public void testStringFunctionsReverse() {
-		String sql = "SELECT * FROM Strings WHERE " +
+		String sql = "SELECT * FROM STRINGS WHERE " +
 				"reverse(C1) = 'Mauricio' and C2 = 'Annibale' and C3 = 'Mozhan'";
 		
 		assertTrue(testExecutePath(sql));
@@ -75,7 +75,7 @@ public class StringsTest extends TestBase {
 	
 	@Test
 	public void refrigeratorReverse() {
-		String sql = "SELECT * FROM Strings WHERE " +
+		String sql = "SELECT * FROM STRINGS WHERE " +
 				"reverse(C1) = 'refrigerator'";
 		
 		assertTrue(testExecutePath(sql));
@@ -84,7 +84,7 @@ public class StringsTest extends TestBase {
 
 	@Test
 	public void testStringFunctionsRight() {
-		String sql = "SELECT * FROM Strings WHERE " +
+		String sql = "SELECT * FROM STRINGS WHERE " +
 				"c1 like 'mau%' and right(C1, 3) = 'cio' and C2 = 'Annibale' and C3 = 'Mozhan'";
 		
 		assertTrue(testExecutePath(sql));
@@ -93,16 +93,16 @@ public class StringsTest extends TestBase {
 	
 	@Test
 	public void testStringEqualitiesAndNull() {
-		String sql = "SELECT * FROM Strings WHERE " +
-				"C1 = 'Mauricio' and C2 = 'Annibale' and C3 = 'Mozhan' and C4 = 'Jeroen' and C5 = 'Arie' and c6 is null";
+		String sql = "SELECT * FROM STRINGS WHERE " +
+				"C1 = 'Mauricio' and C2 = 'Annibale' and C3 = 'Mozhan' and C4 = 'Jeroen' and C5 = 'Arie' and C6 is null";
 		
 		assertTrue(testExecutePath(sql));
 	}
 	
 	@Test
 	public void testDifferent() {
-		String sql = "SELECT * FROM Strings WHERE " +
-				"C1 = 'Mauricio' and C2 != 'Annibale' and C3 = 'Mozhan' and C4 = 'Jeroen' and C5 != 'Arie' and c6 is null";
+		String sql = "SELECT * FROM STRINGS WHERE " +
+				"C1 = 'Mauricio' and C2 != 'Annibale' and C3 = 'Mozhan' and C4 = 'Jeroen' and C5 != 'Arie' and C6 is null";
 		
 		assertTrue(testExecutePath(sql));
 	}
@@ -110,7 +110,7 @@ public class StringsTest extends TestBase {
 	@Test
 	public void testBigStrings() {
 		
-		String sql = "SELECT * FROM Strings WHERE " +
+		String sql = "SELECT * FROM STRINGS WHERE " +
 				"C1 = '71b756b6dadb58257371b6c636517c7c665214921154776a01ae1424167c9a6d' and "
 				+ "C2 = '71b756b6dadb58257371b6cdasdasd517c7c665214921154776a01ae1424167c9a6d' and "
 				+ "C3 = '71b756b6dadb58257371b6c636517c7c665214921154776a01fdsfdfsdfd4167c9a6d' and "
@@ -122,7 +122,7 @@ public class StringsTest extends TestBase {
 
 	@Test
 	public void testStringsInSubQueries() {
-		String sql = "SELECT C1 FROM Strings where c1 in (select c1 from Strings2 where c1 = 'Mauricio')";
+		String sql = "SELECT C1 FROM STRINGS where c1 in (select c1 from STRINGS2 where c1 = 'Mauricio')";
 		
 		assertTrue(testExecutePath(sql));
 	}
@@ -143,7 +143,7 @@ public class StringsTest extends TestBase {
 	
 	@Test
 	public void testStringsAndJoins() {
-		String sql = "SELECT C1 FROM strings s1 join strings2 s2 on s1.c1 = s2.c2 where c3 = 'Jeroen'";
+		String sql = "SELECT C1 FROM STRINGS s1 join strings2 s2 on s1.c1 = s2.c2 where c3 = 'Jeroen'";
 		
 		assertTrue(testExecutePath(sql));
 	}
@@ -205,7 +205,7 @@ public class StringsTest extends TestBase {
 				"   signature  varchar(140)  DEFAULT NULL"+
 				")");
 		
-		String sql = "SELECT NAME, COMMUNICATION_TYPE, COMMUNICATION_MEDIUM, COMMENT_TYPE, CONTENT, SENDER, SENDER_FULL_NAME, CREATION, SUBJECT, DELIVERY_STATUS, LIKED_BY, TIMELINE_DOCTYPE, TIMELINE_NAME, REFERENCE_DOCTYPE, REFERENCE_NAME, LINK_DOCTYPE, LINK_NAME, 'Communication' AS DOCTYPE FROM TABCOMMUNICATION WHERE ( COMMUNICATION_TYPE IS NULL ) AND ( COMMENT_TYPE IN ( 'Created', 'Updated', 'Submitted', 'Cancelled', 'Deleted' ) ) AND ( ( TIMELINE_DOCTYPE = 'Task' AND TIMELINE_NAME = 'TASK00009' ) ) AND NOT ((REFERENCE_DOCTYPE = 'Task' AND REFERENCE_NAME = 'TASK00009'))";
+		String sql = "SELECT name, communication_type, communication_medium, comment_type, content, sender, sender_full_name, creation, subject, delivery_status, liked_by, timeline_doctype, timeline_name, reference_doctype, reference_name, link_doctype, link_name, 'Communication' AS DOCTYPE FROM tabCommunication WHERE ( communication_type IS NULL ) AND ( comment_type IN ( 'Created', 'Updated', 'Submitted', 'Cancelled', 'Deleted' ) ) AND ( ( timeline_doctype = 'Task' AND timeline_name = 'TASK00009' ) ) AND NOT ((reference_doctype = 'Task' AND reference_name = 'TASK00009'))";
 		
 		assertTrue(testExecutePath(sql));
 		

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/SubqueryFromTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/SubqueryFromTest.java
@@ -15,7 +15,7 @@ public class SubqueryFromTest extends TestBase {
 	 */
 	@Test
 	public void test1() {
-		assertTrue(testExecutePath("SELECT * FROM (SELECT Product, Price FROM products GROUP BY Product, Price) t"));
+		assertTrue(testExecutePath("SELECT * FROM (SELECT PRODUCT, PRICE FROM PRODUCTS GROUP BY PRODUCT, PRICE) T"));
 	}
 	
 	/**
@@ -23,7 +23,7 @@ public class SubqueryFromTest extends TestBase {
 	 */
 	@Test
 	public void test2() {
-		assertTrue(testExecutePath("SELECT * FROM (SELECT Product, Price FROM products WHERE Product = 'A' GROUP BY Product, Price) t"));
+		assertTrue(testExecutePath("SELECT * FROM (SELECT PRODUCT, PRICE FROM PRODUCTS WHERE PRODUCT = 'A' GROUP BY PRODUCT, PRICE) T"));
 	}
 	
 	/**
@@ -31,7 +31,7 @@ public class SubqueryFromTest extends TestBase {
 	 */
 	@Test
 	public void test3() {
-		assertTrue(testExecutePath("SELECT * FROM (SELECT Product, Price FROM products GROUP BY Product, Price) t WHERE Price > 5 AND Price < 20"));
+		assertTrue(testExecutePath("SELECT * FROM (SELECT PRODUCT, PRICE FROM PRODUCTS GROUP BY PRODUCT, PRICE) T WHERE PRICE > 5 AND PRICE < 20"));
 	}
 	
 	/**
@@ -39,7 +39,7 @@ public class SubqueryFromTest extends TestBase {
 	 */
 	@Test
 	public void test4() {
-		assertTrue(testExecutePath("SELECT * FROM (SELECT Product, Price FROM products WHERE Product = 'A' GROUP BY Product, Price) t WHERE Price > 5 AND Price < 20"));
+		assertTrue(testExecutePath("SELECT * FROM (SELECT PRODUCT, PRICE FROM PRODUCTS WHERE PRODUCT = 'A' GROUP BY PRODUCT, PRICE) T WHERE PRICE > 5 AND PRICE < 20"));
 	}
 	
 	/**
@@ -47,7 +47,7 @@ public class SubqueryFromTest extends TestBase {
 	 */
 	@Test
 	public void test5() {
-		assertTrue(testExecutePath("SELECT * FROM (SELECT * FROM (SELECT Product, Price FROM products WHERE Product = 'A' GROUP BY Product, Price) t WHERE Price > 5 GROUP BY Product, Price) t WHERE Price < 20"));
+		assertTrue(testExecutePath("SELECT * FROM (SELECT * FROM (SELECT PRODUCT, PRICE FROM PRODUCTS WHERE PRODUCT = 'A' GROUP BY PRODUCT, PRICE) T WHERE PRICE > 5 GROUP BY PRODUCT, PRICE) T WHERE PRICE < 20"));
 	}
 	
 	/**
@@ -55,7 +55,7 @@ public class SubqueryFromTest extends TestBase {
 	 */
 	@Test
 	public void test6() {
-		assertTrue(testExecutePath("SELECT * FROM (SELECT Product, Price FROM products GROUP BY Product, Price HAVING SUM(Price) > 4) t WHERE Product = 'A'"));
+		assertTrue(testExecutePath("SELECT * FROM (SELECT PRODUCT, PRICE FROM PRODUCTS GROUP BY PRODUCT, PRICE HAVING SUM(PRICE) > 4) T WHERE PRODUCT = 'A'"));
 	}
 	
 	/**
@@ -63,7 +63,7 @@ public class SubqueryFromTest extends TestBase {
 	 */
 	@Test
 	public void test7() {
-		assertTrue(testExecutePath("SELECT Product FROM (SELECT Product, Price FROM products GROUP BY Product, Price) t GROUP BY Product HAVING SUM(Price) > 4"));
+		assertTrue(testExecutePath("SELECT PRODUCT FROM (SELECT PRODUCT, PRICE FROM PRODUCTS GROUP BY PRODUCT, PRICE) T GROUP BY PRODUCT HAVING SUM(PRICE) > 4"));
 	}
 	
 	/**
@@ -71,6 +71,6 @@ public class SubqueryFromTest extends TestBase {
 	 */
 	@Test
 	public void test8() {
-		assertTrue(testExecutePath("SELECT Product FROM (SELECT Product, Price FROM products GROUP BY Product, Price HAVING SUM(Price) < 10) t GROUP BY Product HAVING SUM(Price) > 4"));
+		assertTrue(testExecutePath("SELECT PRODUCT FROM (SELECT PRODUCT, PRICE FROM PRODUCTS GROUP BY PRODUCT, PRICE HAVING SUM(PRICE) < 10) T GROUP BY PRODUCT HAVING SUM(PRICE) > 4"));
 	}
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/SubquerySelectWhereTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/SubquerySelectWhereTest.java
@@ -12,17 +12,17 @@ public class SubquerySelectWhereTest extends TestBase {
 
 	@Test
 	public void test1() {
-		assertTrue(testExecutePath("SELECT * FROM products t WHERE LENGTH(t.Product) = 1 AND t.Price = (SELECT MAX(Price) FROM products)"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS T WHERE LENGTH(T.PRODUCT) = 1 AND T.PRICE = (SELECT MAX(PRICE) FROM PRODUCTS)"));
 	}
 
 	@Test
 	public void test2() {
-		assertTrue(testExecutePath("SELECT * FROM (SELECT Product, Price FROM products t WHERE LENGTH(t.Product) = 1 GROUP BY Product, Price) t WHERE t.Price = (SELECT MAX(Price) FROM products)"));
+		assertTrue(testExecutePath("SELECT * FROM (SELECT PRODUCT, PRICE FROM PRODUCTS T WHERE LENGTH(T.PRODUCT) = 1 GROUP BY PRODUCT, PRICE) T WHERE T.PRICE = (SELECT MAX(PRICE) FROM PRODUCTS)"));
 	}
 
 	@Test
 	public void test3() {
-		assertTrue(testExecutePath("SELECT * FROM (SELECT Product, Price FROM products t WHERE LENGTH(t.Product) = 1 GROUP BY Product, Price) t WHERE t.Price < (SELECT MAX(Type) FROM product_detail t2 WHERE t.Product = t2.Name)"));
+		assertTrue(testExecutePath("SELECT * FROM (SELECT PRODUCT, PRICE FROM PRODUCTS T WHERE LENGTH(T.PRODUCT) = 1 GROUP BY PRODUCT, PRICE) T WHERE T.PRICE < (SELECT MAX(TYPE) FROM PRODUCT_DETAIL T2 WHERE T.PRODUCT = T2.NAME)"));
 	}
 
 	/**
@@ -30,7 +30,7 @@ public class SubquerySelectWhereTest extends TestBase {
 	 */
 	@Test
 	public void test4() {
-		assertTrue(testExecutePath("SELECT (SELECT MAX(Type) FROM Product_Detail WHERE Name = 'A') Subinfo, Product FROM Products"));
+		assertTrue(testExecutePath("SELECT (SELECT MAX(TYPE) FROM PRODUCT_DETAIL WHERE NAME = 'A') SUBINFO, PRODUCT FROM PRODUCTS"));
 	}
 	
 	/**
@@ -38,12 +38,12 @@ public class SubquerySelectWhereTest extends TestBase {
 	 */
 	@Test
 	public void test5() {
-		assertTrue(testExecutePath("SELECT * FROM (SELECT (SELECT MAX(Type) FROM Product_Detail WHERE Name = 'A') Subinfo, Product FROM Products) t WHERE SubInfo > 10 AND SubInfo < 20"));
+		assertTrue(testExecutePath("SELECT * FROM (SELECT (SELECT MAX(TYPE) FROM PRODUCT_DETAIL WHERE NAME = 'A') SUBINFO, PRODUCT FROM PRODUCTS) T WHERE SUBINFO > 10 AND SUBINFO < 20"));
 	}
 	
 	@Test
 	public void test6() {
-		assertTrue(testExecutePath("SELECT * FROM Products t WHERE t.Price < (SELECT MAX(Type) FROM product_detail t2 WHERE t.Product = t2.Name)"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS T WHERE T.PRICE < (SELECT MAX(TYPE) FROM PRODUCT_DETAIL T2 WHERE T.PRODUCT = T2.NAME)"));
 	}
 	
 	/**
@@ -51,17 +51,17 @@ public class SubquerySelectWhereTest extends TestBase {
 	 */
 	@Test
 	public void test7() {
-		assertTrue(testExecutePath("SELECT * FROM Products t WHERE t.Price < (SELECT MAX(Type) FROM (SELECT Name, Type FROM Product_Detail WHERE LENGTH(Name) = 2) t2 WHERE t.Product = t2.Name)"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS T WHERE T.PRICE < (SELECT MAX(TYPE) FROM (SELECT NAME, TYPE FROM PRODUCT_DETAIL WHERE LENGTH(NAME) = 2) T2 WHERE T.PRODUCT = T2.NAME)"));
 	}
 	
 	@Test
 	public void test8() {
-		assertTrue(testExecutePath("SELECT * FROM Products t WHERE t.Price < (SELECT MAX(Type) FROM (SELECT Name, Type FROM Product_Detail t3 WHERE LENGTH(Name) < t.ID) t2 WHERE t.Product = t2.Name)"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS T WHERE T.PRICE < (SELECT MAX(TYPE) FROM (SELECT NAME, TYPE FROM PRODUCT_DETAIL T3 WHERE LENGTH(NAME) < T.ID) T2 WHERE T.PRODUCT = T2.NAME)"));
 	}
 	
 	@Test
 	public void test9() {
-		assertTrue(testExecutePath("SELECT * FROM Products t WHERE t.Price < (SELECT MAX(Type) FROM Product_Detail t2 WHERE LENGTH(t.Product) = (SELECT MIN(t3.ID) FROM Products t3 WHERE t3.ID >= 0))"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS T WHERE T.PRICE < (SELECT MAX(TYPE) FROM PRODUCT_DETAIL T2 WHERE LENGTH(T.PRODUCT) = (SELECT MIN(T3.ID) FROM PRODUCTS T3 WHERE T3.ID >= 0))"));
 	}
 	
 	/**
@@ -69,7 +69,7 @@ public class SubquerySelectWhereTest extends TestBase {
 	 */
 	@Test
 	public void test10() {
-		assertTrue(testExecutePath("SELECT * FROM Products t WHERE t.Price < (SELECT MAX(Type) FROM Product_Detail t2 WHERE LENGTH(t.Product) = (SELECT MIN(t3.ID) FROM Products t3 WHERE t3.ID >= 0 AND t3.Product = t2.Name))"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS T WHERE T.PRICE < (SELECT MAX(TYPE) FROM PRODUCT_DETAIL T2 WHERE LENGTH(T.PRODUCT) = (SELECT MIN(T3.ID) FROM PRODUCTS T3 WHERE T3.ID >= 0 AND T3.PRODUCT = T2.NAME))"));
 	}
 	
 	/**
@@ -77,6 +77,6 @@ public class SubquerySelectWhereTest extends TestBase {
 	 */
 	@Test
 	public void test11() { 
-		assertTrue(testExecutePath("SELECT * FROM Products t WHERE t.Price < (SELECT MAX(Type) FROM product_detail t2 WHERE t.Product = t2.Name) AND t.Price > (SELECT MAX(Type) FROM product_detail t2 WHERE t.Product = t2.Name) - 10"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS T WHERE T.PRICE < (SELECT MAX(TYPE) FROM PRODUCT_DETAIL T2 WHERE T.PRODUCT = T2.NAME) AND T.PRICE > (SELECT MAX(TYPE) FROM PRODUCT_DETAIL T2 WHERE T.PRODUCT = T2.NAME) - 10"));
 	}
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/WhereTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/WhereTest.java
@@ -12,37 +12,37 @@ public class WhereTest extends TestBase {
 	
 	@Test
 	public void test2() {
-		assertTrue(testExecutePath("SELECT * FROM products WHERE (Price > 10 AND LENGTH(Product) = 1) OR (Price < 8 AND Product = 'A')-- OR (Price < 4 AND Price > 1)"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS WHERE (PRICE > 10 AND LENGTH(PRODUCT) = 1) OR (PRICE < 8 AND PRODUCT = 'A')-- OR (PRICE < 4 AND PRICE > 1)"));
 	}
 	
 	@Test
 	public void test3() {
-		assertTrue(testExecutePath("SELECT * FROM Products WHERE NOT (Price > 1 OR Price < -1)"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS WHERE NOT (PRICE > 1 OR PRICE < -1)"));
 	}
 	
 	@Test
 	public void test4() {
-		assertTrue(testExecutePath("SELECT * FROM Products WHERE LCASE(Product) = 'tv'"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS WHERE LCASE(PRODUCT) = 'TV'"));
 	}
 
 	@Test
 	public void test5() {
-		assertTrue(testExecutePath("SELECT * FROM Products WHERE Price > 10 AND Price < 20"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS WHERE PRICE > 10 AND PRICE < 20"));
 	}
 	
 	@Test
 	public void test6() {
-		assertTrue(testExecutePath("SELECT * FROM Products WHERE Product = 'tv'"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS WHERE PRODUCT = 'TV'"));
 	}
 	
 	/** Test Double equals **/
 	@Test
 	public void test7() {
-		assertTrue(testExecutePath("SELECT * FROM Products WHERE Price = 10"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS WHERE PRICE = 10"));
 	}
 	
 	@Test
 	public void test8() {
-		assertTrue(testExecutePath("SELECT * FROM Products WHERE Price = 10.59"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS WHERE PRICE = 10.59"));
 	}
 }

--- a/ga/src/test/java/nl/tudelft/serg/evosql/test/WhereTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/test/WhereTest.java
@@ -22,7 +22,7 @@ public class WhereTest extends TestBase {
 	
 	@Test
 	public void test4() {
-		assertTrue(testExecutePath("SELECT * FROM PRODUCTS WHERE LCASE(PRODUCT) = 'TV'"));
+		assertTrue(testExecutePath("SELECT * FROM PRODUCTS WHERE LCASE(PRODUCT) = 'tv'"));
 	}
 
 	@Test


### PR DESCRIPTION
GA transformed table and column names to upper case names which would cause trouble in unit test generation. Removing this feature does not seem to cause any trouble for Sqlfpc or jSQLparser (for which it was intended). See #29 for details.