### PR TITLE
Modify generated assertions to run the production query

### DIFF
--- a/brew/src/main/java/nl/tudelft/serg/evosql/brew/data/Path.java
+++ b/brew/src/main/java/nl/tudelft/serg/evosql/brew/data/Path.java
@@ -18,4 +18,7 @@ public class Path {
 
     /** The path number. */
     private final int pathNumber;
+
+    /** If path is a success from production query (returns something). */
+    private final boolean success;
 }

--- a/brew/src/main/java/nl/tudelft/serg/evosql/brew/db/EvoSQLRunner.java
+++ b/brew/src/main/java/nl/tudelft/serg/evosql/brew/db/EvoSQLRunner.java
@@ -52,7 +52,7 @@ public class EvoSQLRunner implements QueryRunner {
                 convertFixture(pathResult.getFixture()),
                 pathResult.getPathSql(),
                 pathResult.getPathNo(),
-                pathResult.isSuccess()
+                pathResult.isProductionSuccess()
         );
     }
 

--- a/brew/src/main/java/nl/tudelft/serg/evosql/brew/db/EvoSQLRunner.java
+++ b/brew/src/main/java/nl/tudelft/serg/evosql/brew/db/EvoSQLRunner.java
@@ -51,7 +51,8 @@ public class EvoSQLRunner implements QueryRunner {
         return new Path(
                 convertFixture(pathResult.getFixture()),
                 pathResult.getPathSql(),
-                pathResult.getPathNo()
+                pathResult.getPathNo(),
+                pathResult.isSuccess()
         );
     }
 

--- a/brew/src/main/java/nl/tudelft/serg/evosql/brew/generator/junit/JUnitGenerator.java
+++ b/brew/src/main/java/nl/tudelft/serg/evosql/brew/generator/junit/JUnitGenerator.java
@@ -337,7 +337,7 @@ public abstract class JUnitGenerator implements Generator {
 
         // Assert
         pTestBuilder.addComment("Assert: verify that at least one resulting row was returned");
-        pTestBuilder.addStatement("$T.assertEquals(result, $L)", assertionClass, path.isSuccess());
+        pTestBuilder.addStatement("$T.assertEquals($L, result)", assertionClass, path.isSuccess());
         return pTestBuilder.build();
     }
 }

--- a/brew/src/test/java/nl/tudelft/serg/evosql/brew/DataGenerator.java
+++ b/brew/src/test/java/nl/tudelft/serg/evosql/brew/DataGenerator.java
@@ -10,6 +10,7 @@ import java.util.*;
 public class DataGenerator {
     /**
      * Creates result set 1.
+     *
      * @return Result set 1.
      */
     public static Result makeResult1() {
@@ -35,8 +36,8 @@ public class DataGenerator {
 
         // Make fixture
         Fixture fixture = new Fixture(Arrays.asList(table1));
-        Path path1 = new Path(fixture, "Select * From table1 Where column1_2 < 1;", 1);
-        Path path2 = new Path(fixture, "Select * From table1 Where column1_2 >= 1;", 2);
+        Path path1 = new Path(fixture, "Select * From table1 Where column1_2 < 1;", 1, true);
+        Path path2 = new Path(fixture, "Select * From table1 Where column1_2 >= 1;", 2, true);
 
         return new Result("Select * From table1 Where column1_2 < 1",
                 Arrays.asList(path1, path2));
@@ -44,6 +45,7 @@ public class DataGenerator {
 
     /**
      * Creates result set 2.
+     *
      * @return Result set 2.
      */
     public static Result makeResult2() {
@@ -93,10 +95,10 @@ public class DataGenerator {
 
         // Make fixture
         Fixture fixture = new Fixture(Arrays.asList(table1, productsTable));
-        Path path1 = new Path(fixture, "Select * From table1, products Where column1_2 < 1 And expired = 0;", 1);
-        Path path2 = new Path(fixture, "Select * From table1, products Where column1_2 < 1 And expired = 1;", 2);
-        Path path3 = new Path(fixture, "Select * From table1, products Where column1_2 >= 1 And Expired = 0;", 3);
-        Path path4 = new Path(fixture, "Select * From table1, products Where column1_2 >= 1 And Expired = 1;", 4);
+        Path path1 = new Path(fixture, "Select * From table1, products Where column1_2 < 1 And expired = 0;", 1, true);
+        Path path2 = new Path(fixture, "Select * From table1, products Where column1_2 < 1 And expired = 1;", 2, true);
+        Path path3 = new Path(fixture, "Select * From table1, products Where column1_2 >= 1 And Expired = 0;", 3, true);
+        Path path4 = new Path(fixture, "Select * From table1, products Where column1_2 >= 1 And Expired = 1;", 4, true);
 
         return new Result("Select * From table1, products Where column1_2 < 1 And Expired = 0",
                 Arrays.asList(path1, path2, path3, path4));

--- a/brew/src/test/java/nl/tudelft/serg/evosql/brew/DataGenerator.java
+++ b/brew/src/test/java/nl/tudelft/serg/evosql/brew/DataGenerator.java
@@ -37,9 +37,9 @@ public class DataGenerator {
         // Make fixture
         Fixture fixture = new Fixture(Arrays.asList(table1));
         Path path1 = new Path(fixture, "Select * From table1 Where column1_2 < 1;", 1, true);
-        Path path2 = new Path(fixture, "Select * From table1 Where column1_2 >= 1;", 2, true);
+        Path path2 = new Path(fixture, "Select * From table1 Where column1_2 >= 1;", 2, false);
 
-        return new Result("Select * From table1 Where column1_2 < 1",
+        return new Result("Select * From table1 Where column1_2 < 1;",
                 Arrays.asList(path1, path2));
     }
 
@@ -96,11 +96,11 @@ public class DataGenerator {
         // Make fixture
         Fixture fixture = new Fixture(Arrays.asList(table1, productsTable));
         Path path1 = new Path(fixture, "Select * From table1, products Where column1_2 < 1 And expired = 0;", 1, true);
-        Path path2 = new Path(fixture, "Select * From table1, products Where column1_2 < 1 And expired = 1;", 2, true);
-        Path path3 = new Path(fixture, "Select * From table1, products Where column1_2 >= 1 And Expired = 0;", 3, true);
-        Path path4 = new Path(fixture, "Select * From table1, products Where column1_2 >= 1 And Expired = 1;", 4, true);
+        Path path2 = new Path(fixture, "Select * From table1, products Where column1_2 < 1 And expired = 1;", 2, false);
+        Path path3 = new Path(fixture, "Select * From table1, products Where column1_2 >= 1 And expired = 0;", 3, false);
+        Path path4 = new Path(fixture, "Select * From table1, products Where column1_2 >= 1 And expired = 1;", 4, true);
 
-        return new Result("Select * From table1, products Where column1_2 < 1 And Expired = 0",
+        return new Result("Select * From table1, products Where column1_2 < 1 And expired = 0;",
                 Arrays.asList(path1, path2, path3, path4));
     }
 }

--- a/brew/src/test/java/nl/tudelft/serg/evosql/brew/db/EvoSQLRunnerTest.java
+++ b/brew/src/test/java/nl/tudelft/serg/evosql/brew/db/EvoSQLRunnerTest.java
@@ -87,6 +87,7 @@ public class EvoSQLRunnerTest {
                 "Select * From table" + n,
                 0,
                 evoSQLFixture,
+                true,
                 0,
                 1,
                 ""

--- a/brew/src/test/resources/java/jUnitGenerator/JUnit4MediumTest.java
+++ b/brew/src/test/resources/java/jUnitGenerator/JUnit4MediumTest.java
@@ -75,7 +75,7 @@ public class JUnit4MediumTest {
     // Act: run a selection query on the database
     boolean result = runSQL("Select * From table1, products Where column1_2 < 1 And expired = 0;", false);
     // Assert: verify that at least one resulting row was returned
-    Assert.assertTrue(result);
+    Assert.assertEquals(true, result);
   }
 
   @Test
@@ -84,9 +84,9 @@ public class JUnit4MediumTest {
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`) VALUES (1, 'String of row 1'), (2, 'String of row 2');", true);
     runSQL("INSERT INTO `products` (`product_name`, `expired`, `expiry_date`) VALUES ('Milk', 0, '2018-03-22 00:00:00'), ('Yogurt', 1, '2018-03-15 00:00:00'), ('Salt', 0, '2025-12-31 23:59:59');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1, products Where column1_2 < 1 And expired = 1;", false);
+    boolean result = runSQL("Select * From table1, products Where column1_2 < 1 And expired = 0;", false);
     // Assert: verify that at least one resulting row was returned
-    Assert.assertTrue(result);
+    Assert.assertEquals(false, result);
   }
 
   @Test
@@ -95,9 +95,9 @@ public class JUnit4MediumTest {
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`) VALUES (1, 'String of row 1'), (2, 'String of row 2');", true);
     runSQL("INSERT INTO `products` (`product_name`, `expired`, `expiry_date`) VALUES ('Milk', 0, '2018-03-22 00:00:00'), ('Yogurt', 1, '2018-03-15 00:00:00'), ('Salt', 0, '2025-12-31 23:59:59');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1, products Where column1_2 >= 1 And Expired = 0;", false);
+    boolean result = runSQL("Select * From table1, products Where column1_2 < 1 And expired = 0;", false);
     // Assert: verify that at least one resulting row was returned
-    Assert.assertTrue(result);
+    Assert.assertEquals(false, result);
   }
 
   @Test
@@ -106,8 +106,8 @@ public class JUnit4MediumTest {
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`) VALUES (1, 'String of row 1'), (2, 'String of row 2');", true);
     runSQL("INSERT INTO `products` (`product_name`, `expired`, `expiry_date`) VALUES ('Milk', 0, '2018-03-22 00:00:00'), ('Yogurt', 1, '2018-03-15 00:00:00'), ('Salt', 0, '2025-12-31 23:59:59');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1, products Where column1_2 >= 1 And Expired = 1;", false);
+    boolean result = runSQL("Select * From table1, products Where column1_2 < 1 And expired = 0;", false);
     // Assert: verify that at least one resulting row was returned
-    Assert.assertTrue(result);
+    Assert.assertEquals(true, result);
   }
 }

--- a/brew/src/test/resources/java/jUnitGenerator/JUnit4MediumTest.java
+++ b/brew/src/test/resources/java/jUnitGenerator/JUnit4MediumTest.java
@@ -12,6 +12,11 @@ import org.junit.Test;
 @Generated("nl.tudelft.serg.evosql.brew.generator.junit.JUnit4TestGenerator")
 public class JUnit4MediumTest {
   /**
+   * The production query used to test the generated fixtures on.
+   */
+  private static final String PRODUCTION_QUERY = "Select * From table1, products Where column1_2 < 1 And expired = 0;";
+
+  /**
    * This method should connect to your database and execute the given query.
    * In order for the assertions to work correctly this method must return true in the case
    * that the query yields at least one result and false if there is no result.
@@ -73,7 +78,7 @@ public class JUnit4MediumTest {
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`) VALUES (1, 'String of row 1'), (2, 'String of row 2');", true);
     runSQL("INSERT INTO `products` (`product_name`, `expired`, `expiry_date`) VALUES ('Milk', 0, '2018-03-22 00:00:00'), ('Yogurt', 1, '2018-03-15 00:00:00'), ('Salt', 0, '2025-12-31 23:59:59');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1, products Where column1_2 < 1 And expired = 0;", false);
+    boolean result = runSQL(PRODUCTION_QUERY, false);
     // Assert: verify that at least one resulting row was returned
     Assert.assertEquals(true, result);
   }
@@ -84,7 +89,7 @@ public class JUnit4MediumTest {
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`) VALUES (1, 'String of row 1'), (2, 'String of row 2');", true);
     runSQL("INSERT INTO `products` (`product_name`, `expired`, `expiry_date`) VALUES ('Milk', 0, '2018-03-22 00:00:00'), ('Yogurt', 1, '2018-03-15 00:00:00'), ('Salt', 0, '2025-12-31 23:59:59');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1, products Where column1_2 < 1 And expired = 0;", false);
+    boolean result = runSQL(PRODUCTION_QUERY, false);
     // Assert: verify that at least one resulting row was returned
     Assert.assertEquals(false, result);
   }
@@ -95,7 +100,7 @@ public class JUnit4MediumTest {
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`) VALUES (1, 'String of row 1'), (2, 'String of row 2');", true);
     runSQL("INSERT INTO `products` (`product_name`, `expired`, `expiry_date`) VALUES ('Milk', 0, '2018-03-22 00:00:00'), ('Yogurt', 1, '2018-03-15 00:00:00'), ('Salt', 0, '2025-12-31 23:59:59');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1, products Where column1_2 < 1 And expired = 0;", false);
+    boolean result = runSQL(PRODUCTION_QUERY, false);
     // Assert: verify that at least one resulting row was returned
     Assert.assertEquals(false, result);
   }
@@ -106,7 +111,7 @@ public class JUnit4MediumTest {
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`) VALUES (1, 'String of row 1'), (2, 'String of row 2');", true);
     runSQL("INSERT INTO `products` (`product_name`, `expired`, `expiry_date`) VALUES ('Milk', 0, '2018-03-22 00:00:00'), ('Yogurt', 1, '2018-03-15 00:00:00'), ('Salt', 0, '2025-12-31 23:59:59');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1, products Where column1_2 < 1 And expired = 0;", false);
+    boolean result = runSQL(PRODUCTION_QUERY, false);
     // Assert: verify that at least one resulting row was returned
     Assert.assertEquals(true, result);
   }

--- a/brew/src/test/resources/java/jUnitGenerator/JUnit4SmallTest.java
+++ b/brew/src/test/resources/java/jUnitGenerator/JUnit4SmallTest.java
@@ -17,6 +17,11 @@ import org.junit.Test;
 @Generated("nl.tudelft.serg.evosql.brew.generator.junit.JUnit4TestGenerator")
 public class JUnit4SmallTest {
   /**
+   * The production query used to test the generated fixtures on.
+   */
+  private static final String PRODUCTION_QUERY = "Select * From table1 Where column1_2 < 1;";
+
+  /**
    * The JDBC url used to connect to the test database.
    */
   private static final String DB_JDBC_URL = "jdbc:mysql://localhost:3306/evosql_brew_test";
@@ -99,7 +104,7 @@ public class JUnit4SmallTest {
     // Arrange: set up the fixture data
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`, `column1_3`) VALUES (1, 0.5, 'The first row of table 1.'), (2, 1.5, 'The second row.');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1 Where column1_2 < 1;", false);
+    boolean result = runSQL(PRODUCTION_QUERY, false);
     // Assert: verify that at least one resulting row was returned
     Assert.assertEquals(true, result);
   }
@@ -109,7 +114,7 @@ public class JUnit4SmallTest {
     // Arrange: set up the fixture data
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`, `column1_3`) VALUES (1, 0.5, 'The first row of table 1.'), (2, 1.5, 'The second row.');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1 Where column1_2 < 1;", false);
+    boolean result = runSQL(PRODUCTION_QUERY, false);
     // Assert: verify that at least one resulting row was returned
     Assert.assertEquals(false, result);
   }

--- a/brew/src/test/resources/java/jUnitGenerator/JUnit4SmallTest.java
+++ b/brew/src/test/resources/java/jUnitGenerator/JUnit4SmallTest.java
@@ -101,7 +101,7 @@ public class JUnit4SmallTest {
     // Act: run a selection query on the database
     boolean result = runSQL("Select * From table1 Where column1_2 < 1;", false);
     // Assert: verify that at least one resulting row was returned
-    Assert.assertTrue(result);
+    Assert.assertEquals(true, result);
   }
 
   @Test
@@ -109,8 +109,8 @@ public class JUnit4SmallTest {
     // Arrange: set up the fixture data
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`, `column1_3`) VALUES (1, 0.5, 'The first row of table 1.'), (2, 1.5, 'The second row.');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1 Where column1_2 >= 1;", false);
+    boolean result = runSQL("Select * From table1 Where column1_2 < 1;", false);
     // Assert: verify that at least one resulting row was returned
-    Assert.assertTrue(result);
+    Assert.assertEquals(false, result);
   }
 }

--- a/brew/src/test/resources/java/jUnitGenerator/JUnit5MediumTest.java
+++ b/brew/src/test/resources/java/jUnitGenerator/JUnit5MediumTest.java
@@ -12,6 +12,11 @@ import org.junit.jupiter.api.Test;
 @Generated("nl.tudelft.serg.evosql.brew.generator.junit.JUnit5TestGenerator")
 public class JUnit5MediumTest {
   /**
+   * The production query used to test the generated fixtures on.
+   */
+  private static final String PRODUCTION_QUERY = "Select * From table1, products Where column1_2 < 1 And expired = 0;";
+
+  /**
    * This method should connect to your database and execute the given query.
    * In order for the assertions to work correctly this method must return true in the case
    * that the query yields at least one result and false if there is no result.
@@ -73,7 +78,7 @@ public class JUnit5MediumTest {
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`) VALUES (1, 'String of row 1'), (2, 'String of row 2');", true);
     runSQL("INSERT INTO `products` (`product_name`, `expired`, `expiry_date`) VALUES ('Milk', 0, '2018-03-22 00:00:00'), ('Yogurt', 1, '2018-03-15 00:00:00'), ('Salt', 0, '2025-12-31 23:59:59');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1, products Where column1_2 < 1 And expired = 0;", false);
+    boolean result = runSQL(PRODUCTION_QUERY, false);
     // Assert: verify that at least one resulting row was returned
     Assertions.assertEquals(true, result);
   }
@@ -84,7 +89,7 @@ public class JUnit5MediumTest {
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`) VALUES (1, 'String of row 1'), (2, 'String of row 2');", true);
     runSQL("INSERT INTO `products` (`product_name`, `expired`, `expiry_date`) VALUES ('Milk', 0, '2018-03-22 00:00:00'), ('Yogurt', 1, '2018-03-15 00:00:00'), ('Salt', 0, '2025-12-31 23:59:59');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1, products Where column1_2 < 1 And expired = 0;", false);
+    boolean result = runSQL(PRODUCTION_QUERY, false);
     // Assert: verify that at least one resulting row was returned
     Assertions.assertEquals(false, result);
   }
@@ -95,7 +100,7 @@ public class JUnit5MediumTest {
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`) VALUES (1, 'String of row 1'), (2, 'String of row 2');", true);
     runSQL("INSERT INTO `products` (`product_name`, `expired`, `expiry_date`) VALUES ('Milk', 0, '2018-03-22 00:00:00'), ('Yogurt', 1, '2018-03-15 00:00:00'), ('Salt', 0, '2025-12-31 23:59:59');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1, products Where column1_2 < 1 And expired = 0;", false);
+    boolean result = runSQL(PRODUCTION_QUERY, false);
     // Assert: verify that at least one resulting row was returned
     Assertions.assertEquals(false, result);
   }
@@ -106,7 +111,7 @@ public class JUnit5MediumTest {
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`) VALUES (1, 'String of row 1'), (2, 'String of row 2');", true);
     runSQL("INSERT INTO `products` (`product_name`, `expired`, `expiry_date`) VALUES ('Milk', 0, '2018-03-22 00:00:00'), ('Yogurt', 1, '2018-03-15 00:00:00'), ('Salt', 0, '2025-12-31 23:59:59');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1, products Where column1_2 < 1 And expired = 0;", false);
+    boolean result = runSQL(PRODUCTION_QUERY, false);
     // Assert: verify that at least one resulting row was returned
     Assertions.assertEquals(true, result);
   }

--- a/brew/src/test/resources/java/jUnitGenerator/JUnit5MediumTest.java
+++ b/brew/src/test/resources/java/jUnitGenerator/JUnit5MediumTest.java
@@ -75,7 +75,7 @@ public class JUnit5MediumTest {
     // Act: run a selection query on the database
     boolean result = runSQL("Select * From table1, products Where column1_2 < 1 And expired = 0;", false);
     // Assert: verify that at least one resulting row was returned
-    Assertions.assertTrue(result);
+    Assertions.assertEquals(true, result);
   }
 
   @Test
@@ -84,9 +84,9 @@ public class JUnit5MediumTest {
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`) VALUES (1, 'String of row 1'), (2, 'String of row 2');", true);
     runSQL("INSERT INTO `products` (`product_name`, `expired`, `expiry_date`) VALUES ('Milk', 0, '2018-03-22 00:00:00'), ('Yogurt', 1, '2018-03-15 00:00:00'), ('Salt', 0, '2025-12-31 23:59:59');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1, products Where column1_2 < 1 And expired = 1;", false);
+    boolean result = runSQL("Select * From table1, products Where column1_2 < 1 And expired = 0;", false);
     // Assert: verify that at least one resulting row was returned
-    Assertions.assertTrue(result);
+    Assertions.assertEquals(false, result);
   }
 
   @Test
@@ -95,9 +95,9 @@ public class JUnit5MediumTest {
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`) VALUES (1, 'String of row 1'), (2, 'String of row 2');", true);
     runSQL("INSERT INTO `products` (`product_name`, `expired`, `expiry_date`) VALUES ('Milk', 0, '2018-03-22 00:00:00'), ('Yogurt', 1, '2018-03-15 00:00:00'), ('Salt', 0, '2025-12-31 23:59:59');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1, products Where column1_2 >= 1 And Expired = 0;", false);
+    boolean result = runSQL("Select * From table1, products Where column1_2 < 1 And expired = 0;", false);
     // Assert: verify that at least one resulting row was returned
-    Assertions.assertTrue(result);
+    Assertions.assertEquals(false, result);
   }
 
   @Test
@@ -106,8 +106,8 @@ public class JUnit5MediumTest {
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`) VALUES (1, 'String of row 1'), (2, 'String of row 2');", true);
     runSQL("INSERT INTO `products` (`product_name`, `expired`, `expiry_date`) VALUES ('Milk', 0, '2018-03-22 00:00:00'), ('Yogurt', 1, '2018-03-15 00:00:00'), ('Salt', 0, '2025-12-31 23:59:59');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1, products Where column1_2 >= 1 And Expired = 1;", false);
+    boolean result = runSQL("Select * From table1, products Where column1_2 < 1 And expired = 0;", false);
     // Assert: verify that at least one resulting row was returned
-    Assertions.assertTrue(result);
+    Assertions.assertEquals(true, result);
   }
 }

--- a/brew/src/test/resources/java/jUnitGenerator/JUnit5SmallTest.java
+++ b/brew/src/test/resources/java/jUnitGenerator/JUnit5SmallTest.java
@@ -101,7 +101,7 @@ public class JUnit5SmallTest {
     // Act: run a selection query on the database
     boolean result = runSQL("Select * From table1 Where column1_2 < 1;", false);
     // Assert: verify that at least one resulting row was returned
-    Assertions.assertTrue(result);
+    Assertions.assertEquals(true, result);
   }
 
   @Test
@@ -109,8 +109,8 @@ public class JUnit5SmallTest {
     // Arrange: set up the fixture data
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`, `column1_3`) VALUES (1, 0.5, 'The first row of table 1.'), (2, 1.5, 'The second row.');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1 Where column1_2 >= 1;", false);
+    boolean result = runSQL("Select * From table1 Where column1_2 < 1;", false);
     // Assert: verify that at least one resulting row was returned
-    Assertions.assertTrue(result);
+    Assertions.assertEquals(false, result);
   }
 }

--- a/brew/src/test/resources/java/jUnitGenerator/JUnit5SmallTest.java
+++ b/brew/src/test/resources/java/jUnitGenerator/JUnit5SmallTest.java
@@ -17,6 +17,11 @@ import org.junit.jupiter.api.Test;
 @Generated("nl.tudelft.serg.evosql.brew.generator.junit.JUnit5TestGenerator")
 public class JUnit5SmallTest {
   /**
+   * The production query used to test the generated fixtures on.
+   */
+  private static final String PRODUCTION_QUERY = "Select * From table1 Where column1_2 < 1;";
+
+  /**
    * The JDBC url used to connect to the test database.
    */
   private static final String DB_JDBC_URL = "jdbc:mysql://localhost:3306/evosql_brew_test";
@@ -99,7 +104,7 @@ public class JUnit5SmallTest {
     // Arrange: set up the fixture data
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`, `column1_3`) VALUES (1, 0.5, 'The first row of table 1.'), (2, 1.5, 'The second row.');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1 Where column1_2 < 1;", false);
+    boolean result = runSQL(PRODUCTION_QUERY, false);
     // Assert: verify that at least one resulting row was returned
     Assertions.assertEquals(true, result);
   }
@@ -109,7 +114,7 @@ public class JUnit5SmallTest {
     // Arrange: set up the fixture data
     runSQL("INSERT INTO `table1` (`column1_1`, `column1_2`, `column1_3`) VALUES (1, 0.5, 'The first row of table 1.'), (2, 1.5, 'The second row.');", true);
     // Act: run a selection query on the database
-    boolean result = runSQL("Select * From table1 Where column1_2 < 1;", false);
+    boolean result = runSQL(PRODUCTION_QUERY, false);
     // Assert: verify that at least one resulting row was returned
     Assertions.assertEquals(false, result);
   }

--- a/ga/src/main/java/nl/tudelft/serg/evosql/EvoSQL.java
+++ b/ga/src/main/java/nl/tudelft/serg/evosql/EvoSQL.java
@@ -200,6 +200,7 @@ public class EvoSQL {
 				if (pathState.approach.hasOutput(generatedFixture)) {
 					// Add success
 					result.addPathSuccess(pathNo, pathSql, pathState.timePassed, generatedFixture
+							, pathState.approach.hasOutput(generatedFixture, sqlToBeTested)
 							, pathState.approach.getGenerations(), pathState.approach.getIndividualCount()
 							, pathState.approach.getExceptions());
 					

--- a/ga/src/main/java/nl/tudelft/serg/evosql/PathResult.java
+++ b/ga/src/main/java/nl/tudelft/serg/evosql/PathResult.java
@@ -7,17 +7,19 @@ public class PathResult {
 	private String pathSql;
 	private Fixture data;
 	private boolean success;
+	private boolean productionSuccess;
 	private String message;
 	private long runtime;
 	private int generations;
 	private int individualCount;
 	private String exceptions;
 	
-	public PathResult(int pathNo, String pathSql, long runtime, Fixture data, int generations, int individualCount, String exceptions) {
+	public PathResult(int pathNo, String pathSql, long runtime, Fixture data, boolean productionSuccess, int generations, int individualCount, String exceptions) {
 		this.pathNo = pathNo;
 		this.pathSql = pathSql;
 		this.data = data;
 		this.success = true;
+		this.productionSuccess = productionSuccess;
 		this.runtime = runtime;
 		this.message = "";
 		this.generations = generations;
@@ -29,6 +31,7 @@ public class PathResult {
 		this.pathNo = pathNo;
 		this.pathSql = pathSql;
 		this.success = false;
+		this.productionSuccess = false;
 		this.message = message;
 		this.runtime = runtime;
 		this.generations = generations;
@@ -50,6 +53,10 @@ public class PathResult {
 
 	public boolean isSuccess() {
 		return success;
+	}
+
+	public boolean isProductionSuccess() {
+		return productionSuccess;
 	}
 
 	public String getMessage() {

--- a/ga/src/main/java/nl/tudelft/serg/evosql/Result.java
+++ b/ga/src/main/java/nl/tudelft/serg/evosql/Result.java
@@ -20,12 +20,12 @@ public class Result {
 		this.coveragePerc = new ArrayList<Double>();
 	}
 	
-	public void addPathSuccess(int pathNo, String pathSql, long runtime, Fixture data, int generations, int individualCount, String exceptions) {
+	public void addPathSuccess(int pathNo, String pathSql, long runtime, Fixture data, boolean productionSuccess, int generations, int individualCount, String exceptions) {
 		int idx = pathNo - 1;
 		while (idx >= pathResults.size()) {
 			pathResults.add(null);
 		}
-		pathResults.set(idx, new PathResult(pathNo, pathSql, runtime, data, generations, individualCount, exceptions));
+		pathResults.set(idx, new PathResult(pathNo, pathSql, runtime, data, productionSuccess, generations, individualCount, exceptions));
 	}
 	
 	public void addPathFailure(int pathNo, String pathSql, long runtime, String message, int generations, int individualCount, String exceptions) {

--- a/ga/src/main/java/nl/tudelft/serg/evosql/metaheuristics/Approach.java
+++ b/ga/src/main/java/nl/tudelft/serg/evosql/metaheuristics/Approach.java
@@ -77,8 +77,16 @@ public abstract class Approach {
 	public boolean hasOutput(Fixture fixture) throws SQLException {
 		return hasOutput(fixture, "", -1);
 	}
-	
+
+	public boolean hasOutput(Fixture fixture, String sql) throws SQLException {
+		return hasOutput(fixture, sql, "", -1);
+	}
+
 	protected boolean hasOutput (Fixture fixture, String excludeTableName, int excludeIndex) throws SQLException {
+		return hasOutput(fixture, pathToTest, excludeTableName, excludeIndex);
+	}
+
+	protected boolean hasOutput (Fixture fixture, String sql, String excludeTableName, int excludeIndex) throws SQLException {
 		// Truncate tables in Instrumented DB
 		for (TableSchema tableSchema : tableSchemas.values()) {
 			genetic.Instrumenter.execute(tableSchema.getTruncateSQL());
@@ -92,11 +100,9 @@ public abstract class Approach {
 		Statement st = genetic.Instrumenter.getStatement();
 
 		try {
-			ResultSet res = st.executeQuery(pathToTest);
-			if (res.next()) // If next returns true there is at least one row.
-				return true;
-			else
-				return false;
+			ResultSet res = st.executeQuery(sql);
+			// If next returns true there is at least one row.
+			return res.next();
 		} catch (SQLException e) {
 			if (!exceptions.contains(e.getMessage())) {
 				exceptions += ", " + e.getMessage();


### PR DESCRIPTION
We followed some of the EvoSQL source code, and found that it runs the path-generated SQL query for each fixture to see if it has outputs. This is done to determine whether fixture generation was successful.

We modified this code to be more general (preserving the 'old' method signature) and added one that does the same, but with an arbitrary SQL query. In our case, the production input query was used here. The result is stored in a flag in PathResult. You can search for `hasOutput` in the codebase or in the diff.

The Brew subproject extracts this information from the PathResult and uses in the generation of assertion statements for the JUnit test generator.