### PR TITLE
Use -1 as a default/error value

### DIFF
--- a/brew/src/main/java/nl/tudelft/serg/evosql/brew/generator/junit/JUnitGenerator.java
+++ b/brew/src/main/java/nl/tudelft/serg/evosql/brew/generator/junit/JUnitGenerator.java
@@ -140,7 +140,7 @@ public abstract class JUnitGenerator implements Generator {
                     .endControlFlow()
                     .nextControlFlow("catch ($T sqlException)", SQLException.class)
                     .addStatement("sqlException.printStackTrace()")
-                    .addStatement("return 0")
+                    .addStatement("return -1")
                     .endControlFlow();
         } else {
             runSQL.addJavadoc(""
@@ -151,7 +151,7 @@ public abstract class JUnitGenerator implements Generator {
                     + "@param  isUpdate Whether the query is a data modification statement.\n"
                     + "@return Whether the query execution has succeeded.\n")
                     .addComment("TODO: Implement method stub")
-                    .addStatement("return 0");
+                    .addStatement("return -1");
         }
 
         return runSQL.build();

--- a/brew/src/test/resources/java/jUnitGenerator/JUnit4MediumTest.java
+++ b/brew/src/test/resources/java/jUnitGenerator/JUnit4MediumTest.java
@@ -27,7 +27,7 @@ public class JUnit4MediumTest {
    */
   private static int runSQL(String sql, boolean isUpdate) {
     // TODO: Implement method stub
-    return 0;
+    return -1;
   }
 
   /**

--- a/brew/src/test/resources/java/jUnitGenerator/JUnit4SmallTest.java
+++ b/brew/src/test/resources/java/jUnitGenerator/JUnit4SmallTest.java
@@ -59,7 +59,7 @@ public class JUnit4SmallTest {
       }
     } catch (SQLException sqlException) {
       sqlException.printStackTrace();
-      return 0;
+      return -1;
     }
   }
 

--- a/brew/src/test/resources/java/jUnitGenerator/JUnit5MediumTest.java
+++ b/brew/src/test/resources/java/jUnitGenerator/JUnit5MediumTest.java
@@ -27,7 +27,7 @@ public class JUnit5MediumTest {
    */
   private static int runSQL(String sql, boolean isUpdate) {
     // TODO: Implement method stub
-    return 0;
+    return -1;
   }
 
   /**

--- a/brew/src/test/resources/java/jUnitGenerator/JUnit5SmallTest.java
+++ b/brew/src/test/resources/java/jUnitGenerator/JUnit5SmallTest.java
@@ -59,7 +59,7 @@ public class JUnit5SmallTest {
       }
     } catch (SQLException sqlException) {
       sqlException.printStackTrace();
-      return 0;
+      return -1;
     }
   }
 


### PR DESCRIPTION
This ensures that tests asserting a result of size `0` also fail on errors / not implemented functions.