### PR TITLE
Schema XML building in separate class

### DIFF
--- a/evaluation/src/main/java/nl/tudelft/serg/evosql/evaluation/tools/AluraPathExtractor.java
+++ b/evaluation/src/main/java/nl/tudelft/serg/evosql/evaluation/tools/AluraPathExtractor.java
@@ -26,8 +26,9 @@ public class AluraPathExtractor extends PathExtractor {
 		List<String> encryptedPaths = new ArrayList<String>();
 		
 		String encryptedSchemaXml;
+		AluraTableXMLFormatter aluraTableXMLFormatter = new AluraTableXMLFormatter(schemaExtractor, query, crypto);
 		try {
-			encryptedSchemaXml = getSchemaXml(query, schemaExtractor);
+			encryptedSchemaXml = aluraTableXMLFormatter.getSchemaXml();
 		} catch (Exception e) {
 			throw new Exception("Failed to extract the schema from the running database.", e);
 		}
@@ -49,38 +50,5 @@ public class AluraPathExtractor extends PathExtractor {
 		return paths;
 	}
 
-	@Override
-	protected String getTableSchemaXml(TableSchema tableSchema) {
-		String result = "<table name=\"" + crypto.encryptName(tableSchema.getName().toUpperCase()) + "\">";
-		
-		for (ColumnSchema columnSchema : tableSchema.getColumns()) {
-			result += getColumnSchemaXml(columnSchema);
-		}
-		
-		result += "</table>";
-		
-		log.debug("xml to sqlfpc: " + result);
-		return result;
-	}
-	
-	@Override
-	protected String getColumnSchemaXml(ColumnSchema columnSchema) {
-		String result = "<column ";
-		
-		result += "name=\"" + crypto.encryptName(columnSchema.getName().toUpperCase()) + "\" ";
-		result += "type=\"" + getTypeXml(columnSchema.getType()) + "\" ";
-		//TODO if we use primary keys
-		/*
-		if (columnSchema.isPrimaryKey()) {
-			result += "key=\"true\"";
-		}
-		*/
-		if (!columnSchema.isNullable()) {
-			result += "notnull=\"true\"";
-		}
-		
-		result += "/>";
-		
-		return result;
-	}
+
 }

--- a/evaluation/src/main/java/nl/tudelft/serg/evosql/evaluation/tools/AluraTableXMLFormatter.java
+++ b/evaluation/src/main/java/nl/tudelft/serg/evosql/evaluation/tools/AluraTableXMLFormatter.java
@@ -1,0 +1,49 @@
+package nl.tudelft.serg.evosql.evaluation.tools;
+
+import nl.tudelft.serg.evosql.db.ISchemaExtractor;
+import nl.tudelft.serg.evosql.db.TableXMLFormatter;
+import nl.tudelft.serg.evosql.sql.ColumnSchema;
+import nl.tudelft.serg.evosql.sql.TableSchema;
+
+public class AluraTableXMLFormatter extends TableXMLFormatter {
+    private Crypto crypto;
+
+    public AluraTableXMLFormatter(ISchemaExtractor schemaExtractor, String query, Crypto crypto) {
+        super(schemaExtractor, query);
+        this.crypto = crypto;
+    }
+
+    @Override
+    protected String getTableSchemaXml(TableSchema tableSchema) {
+        String result = "<table name=\"" + crypto.encryptName(tableSchema.getName().toUpperCase()) + "\">";
+
+        for (ColumnSchema columnSchema : tableSchema.getColumns()) {
+            result += getColumnSchemaXml(columnSchema);
+        }
+
+        result += "</table>";
+
+        return result;
+    }
+
+    @Override
+    protected String getColumnSchemaXml(ColumnSchema columnSchema) {
+        String result = "<column ";
+
+        result += "name=\"" + crypto.encryptName(columnSchema.getName().toUpperCase()) + "\" ";
+        result += "type=\"" + getTypeXml(columnSchema.getType()) + "\" ";
+        //TODO if we use primary keys
+		/*
+		if (columnSchema.isPrimaryKey()) {
+			result += "key=\"true\"";
+		}
+		*/
+        if (!columnSchema.isNullable()) {
+            result += "notnull=\"true\"";
+        }
+
+        result += "/>";
+
+        return result;
+    }
+}

--- a/ga/src/main/java/nl/tudelft/serg/evosql/db/TableXMLFormatter.java
+++ b/ga/src/main/java/nl/tudelft/serg/evosql/db/TableXMLFormatter.java
@@ -1,0 +1,90 @@
+package nl.tudelft.serg.evosql.db;
+
+import nl.tudelft.serg.evosql.fixture.type.DBString;
+import nl.tudelft.serg.evosql.fixture.type.DBType;
+import nl.tudelft.serg.evosql.sql.ColumnSchema;
+import nl.tudelft.serg.evosql.sql.TableSchema;
+
+import java.util.Map;
+
+/**
+ * Originally contained in class {@link nl.tudelft.serg.evosql.path.PathExtractor}.
+ *
+ * This class finds all the tables in a query and converts it into XML format compatible with
+ * SQLFpc and SQLMutation.
+ */
+public class TableXMLFormatter {
+    private ISchemaExtractor schemaExtractor;
+    private String query;
+
+    public TableXMLFormatter(ISchemaExtractor schemaExtractor, String query) {
+        this.schemaExtractor = schemaExtractor;
+        this.query = query;
+    }
+
+    /**
+     * Builds the schema XML
+     * @return tables from query in XML format.
+     */
+    public String getSchemaXml() {
+        String result= "<schema>";
+
+        Map<String, TableSchema> tableSchemas = schemaExtractor.getTablesFromQuery(query);
+
+        for (TableSchema tableSchema : tableSchemas.values()) {
+            result += getTableSchemaXml(tableSchema);
+        }
+
+        result += "</schema>";
+
+        return result;
+    }
+
+    protected String getTableSchemaXml(TableSchema tableSchema) {
+        String result = "<table name=\"" + tableSchema.getName() + "\">";
+
+        for (ColumnSchema columnSchema : tableSchema.getColumns()) {
+            result += getColumnSchemaXml(columnSchema);
+        }
+
+        result += "</table>";
+
+        return result;
+    }
+
+    protected String getColumnSchemaXml(ColumnSchema columnSchema) {
+        String result = "<column ";
+
+        result += "name=\"" + columnSchema.getName() + "\" ";
+        result += "type=\"" + getTypeXml(columnSchema.getType()) + "\" ";
+        //TODO if we use primary keys
+		/*
+		if (columnSchema.isPrimaryKey()) {
+			result += "key=\"true\"";
+		}
+		*/
+        if (!columnSchema.isNullable()) {
+            result += "notnull=\"true\"";
+        }
+
+        result += "/>";
+
+        return result;
+    }
+
+    /**
+     * Converts evosql types to the correct string for SQLFpc
+     * @param type
+     * @return
+     */
+    protected String getTypeXml(DBType type) {
+        String result = type.getNormalizedTypeString().toLowerCase();
+
+        if (type instanceof DBString)
+            result = "varchar";
+
+        return result;
+    }
+
+
+}

--- a/ga/src/main/java/nl/tudelft/serg/evosql/path/PathExtractor.java
+++ b/ga/src/main/java/nl/tudelft/serg/evosql/path/PathExtractor.java
@@ -10,6 +10,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import nl.tudelft.serg.evosql.db.ISchemaExtractor;
+import nl.tudelft.serg.evosql.db.TableXMLFormatter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
@@ -49,8 +50,9 @@ public class PathExtractor {
 		List<String> paths = new ArrayList<String>();
 		
 		String schemaXml;
+		TableXMLFormatter tableXMLFormatter = new TableXMLFormatter(schemaExtractor, query);
 		try {
-			schemaXml = getSchemaXml(query, schemaExtractor);
+			schemaXml = tableXMLFormatter.getSchemaXml();
 		} catch (Exception e) {
 			throw new Exception("Failed to extract the schema from the running database.", e);
 		}
@@ -63,73 +65,7 @@ public class PathExtractor {
 		return paths;
 	}
 	
-	/**
-	 * Builds the schema XML
-	 * @param query
-	 * @param schemaExtractor
-	 * @return
-	 */
-	protected String getSchemaXml(String query, ISchemaExtractor schemaExtractor) {
-		String result= "<schema>";
-		
-		Map<String, TableSchema> tableSchemas = schemaExtractor.getTablesFromQuery(query);
-		
-		for (TableSchema tableSchema : tableSchemas.values()) {
-			result += getTableSchemaXml(tableSchema);
-		}
-		
-		result += "</schema>";
-		
-		return result;
-	}
-	
-	protected String getTableSchemaXml(TableSchema tableSchema) {
-		String result = "<table name=\"" + tableSchema.getName() + "\">";
-		
-		for (ColumnSchema columnSchema : tableSchema.getColumns()) {
-			result += getColumnSchemaXml(columnSchema);
-		}
-		
-		result += "</table>";
-		
-		log.debug("xml to sqlfpc: " + result);
-		return result;
-	}
-	
-	protected String getColumnSchemaXml(ColumnSchema columnSchema) {
-		String result = "<column ";
-		
-		result += "name=\"" + columnSchema.getName() + "\" ";
-		result += "type=\"" + getTypeXml(columnSchema.getType()) + "\" ";
-		//TODO if we use primary keys
-		/*
-		if (columnSchema.isPrimaryKey()) {
-			result += "key=\"true\"";
-		}
-		*/
-		if (!columnSchema.isNullable()) {
-			result += "notnull=\"true\"";
-		}
-		
-		result += "/>";
-		
-		return result;
-	}
-	
-	/**
-	 * Converts evosql types to the correct string for SQLFpc
-	 * @param type
-	 * @return
-	 */
-	protected String getTypeXml(DBType type) {
-		String result = type.getNormalizedTypeString().toLowerCase();
-		
-		if (type instanceof DBString)
-			result = "varchar";
-		
-		return result;
-	}
-	
+
 	/**
 	 * Extracts all SQL paths into list
 	 * @param sqlfpcXml XML from the web service

--- a/ga/src/main/java/nl/tudelft/serg/evosql/path/PathExtractor.java
+++ b/ga/src/main/java/nl/tudelft/serg/evosql/path/PathExtractor.java
@@ -4,7 +4,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -21,11 +20,6 @@ import org.w3c.dom.NodeList;
 import in2test.application.common.SQLToolsConfig;
 import in2test.application.services.SQLFpcWSFacade;
 import nl.tudelft.serg.evosql.EvoSQLException;
-import nl.tudelft.serg.evosql.db.SchemaExtractor;
-import nl.tudelft.serg.evosql.fixture.type.DBString;
-import nl.tudelft.serg.evosql.fixture.type.DBType;
-import nl.tudelft.serg.evosql.sql.ColumnSchema;
-import nl.tudelft.serg.evosql.sql.TableSchema;
 import nl.tudelft.serg.evosql.sql.parser.SqlSecurer;
 
 public class PathExtractor {

--- a/ga/src/test/java/nl/tudelft/serg/evosql/db/TableXMLFormatterTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/db/TableXMLFormatterTest.java
@@ -1,0 +1,23 @@
+package nl.tudelft.serg.evosql.db;
+
+import nl.tudelft.serg.evosql.sql.TableSchema;
+import org.junit.jupiter.api.BeforeAll;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+
+public class TableXMLFormatterTest {
+    @Mock
+    private ISchemaExtractor schemaExtractor;
+    private TableXMLFormatter tableXMLFormatter;
+
+    @BeforeAll
+    public void setup() {
+        Map<String, TableSchema> schemaMap = new HashMap<>();
+        Mockito.when(schemaExtractor.getTablesFromQuery(any(String.class))).thenReturn(schemaMap);
+    }
+}

--- a/ga/src/test/java/nl/tudelft/serg/evosql/db/TableXMLFormatterTest.java
+++ b/ga/src/test/java/nl/tudelft/serg/evosql/db/TableXMLFormatterTest.java
@@ -1,23 +1,48 @@
 package nl.tudelft.serg.evosql.db;
 
+import nl.tudelft.serg.evosql.fixture.type.DBString;
+import nl.tudelft.serg.evosql.sql.ColumnSchema;
 import nl.tudelft.serg.evosql.sql.TableSchema;
-import org.junit.jupiter.api.BeforeAll;
-import org.mockito.Mock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 
 public class TableXMLFormatterTest {
-    @Mock
+
     private ISchemaExtractor schemaExtractor;
     private TableXMLFormatter tableXMLFormatter;
+    static final String QUERY = "SELECT username, email FROM users WHERE username='test user'";
 
-    @BeforeAll
+    @Before
     public void setup() {
+        schemaExtractor = Mockito.mock(SchemaExtractor.class);
         Map<String, TableSchema> schemaMap = new HashMap<>();
+        List<ColumnSchema> columnSchemas = new ArrayList<>();
+        TableSchema tableSchema = new TableSchema("users", columnSchemas);
+        columnSchemas.add(new ColumnSchema(tableSchema, "username", new DBString(500), false, false));
+        columnSchemas.add(new ColumnSchema(tableSchema, "email", new DBString(500), false, false));
+        schemaMap.put("test", tableSchema);
         Mockito.when(schemaExtractor.getTablesFromQuery(any(String.class))).thenReturn(schemaMap);
+    }
+
+    @Test
+    public void queryTest() {
+        tableXMLFormatter = new TableXMLFormatter(schemaExtractor, QUERY);
+        String expected =   "<schema>" +
+                                "<table name=\"users\">" +
+                                    "<column name=\"username\" type=\"varchar\" notnull=\"true\"/>" +
+                                    "<column name=\"email\" type=\"varchar\" notnull=\"true\"/>" +
+                                "</table>" +
+                            "</schema>";
+        String actual = tableXMLFormatter.getSchemaXml();
+        Assert.assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
The behavior in `PathExtractor` that formats the tables in a query to a SQLFpc compatible XML format has been moved to a separate class such that it can be reused to also do this when requesting the mutations of a query through [SQLMutation](https://in2test.lsi.uniovi.es/sqlmutation/?lang=en).